### PR TITLE
convert tabs to spaces

### DIFF
--- a/actypes.d
+++ b/actypes.d
@@ -9,11 +9,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.	 If not, see <http://www.gnu.org/licenses/>.
  */
 
 module actypes;
@@ -53,7 +53,7 @@ public:
 
 	/**
 	 * Params:
-	 *     name = the symbol's name
+	 *	   name = the symbol's name
 	 */
 	this(string name)
 	{
@@ -62,8 +62,8 @@ public:
 
 	/**
 	 * Params:
-	 *     name = the symbol's name
-	 *     kind = the symbol's completion kind
+	 *	   name = the symbol's name
+	 *	   kind = the symbol's completion kind
 	 */
 	this(string name, CompletionKind kind)
 	{
@@ -73,9 +73,9 @@ public:
 
 	/**
 	 * Params:
-	 *     name = the symbol's name
-	 *     kind = the symbol's completion kind
-	 *     resolvedType = the resolved type of the symbol
+	 *	   name = the symbol's name
+	 *	   kind = the symbol's completion kind
+	 *	   resolvedType = the resolved type of the symbol
 	 */
 	this(string name, CompletionKind kind, ACSymbol resolvedType)
 	{
@@ -150,8 +150,8 @@ public:
 
 	/**
 	 * Params:
-	 *     start = the index of the opening brace
-	 *     end = the index of the closing brace
+	 *	   start = the index of the opening brace
+	 *	   end = the index of the closing brace
 	 */
 	this(size_t start, size_t end)
 	{
@@ -220,7 +220,7 @@ public:
 		ACSymbol[] currentMatches = symbols.filter!(a => a.name == name)().array();
 		if (currentMatches.length == 0 && parent !is null)
 			return parent.findSymbolsInScope(name);
-	    return currentMatches;
+		return currentMatches;
 	}
 
 	/**

--- a/acvisitor.d
+++ b/acvisitor.d
@@ -9,11 +9,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.	 If not, see <http://www.gnu.org/licenses/>.
  */
 
 module acvisitor;

--- a/autocomplete.d
+++ b/autocomplete.d
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.	 If not, see <http://www.gnu.org/licenses/>.
  ******************************************************************************/
 
 module autocomplete;
@@ -98,7 +98,7 @@ AutocompleteResponse complete(AutocompleteRequest request, string[] importPaths)
 			break;
 		}
 	}
-	else if (beforeTokens.length >= 2 && beforeTokens[$ - 1] ==  TokenType.dot)
+	else if (beforeTokens.length >= 2 && beforeTokens[$ - 1] ==	 TokenType.dot)
 	{
 dotCompletion:
 		switch (beforeTokens[$ - 2].type)

--- a/client.d
+++ b/client.d
@@ -9,11 +9,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.	 If not, see <http://www.gnu.org/licenses/>.
  */
 
 module client;
@@ -182,33 +182,33 @@ void printHelp(string programName)
 {
 	writefln(
 `
-    Usage: %1$s [Options] [FILENAME]
+	Usage: %1$s [Options] [FILENAME]
 
-    A file name is optional. If it is given, autocomplete information will be
-    given for the file specified. If it is missing, input will be read from
-    stdin instead.
+	A file name is optional. If it is given, autocomplete information will be
+	given for the file specified. If it is missing, input will be read from
+	stdin instead.
 
-    Source code is assumed to be UTF-8 encoded and must not exceed 4 megabytes.
+	Source code is assumed to be UTF-8 encoded and must not exceed 4 megabytes.
 
 Options:
-    --help | -h
-        Displays this help message
+	--help | -h
+		Displays this help message
 
-    --cursorPos | -c position
-        Provides auto-completion at the given cursor position. The cursor
-        position is measured in bytes from the beginning of the source code.
+	--cursorPos | -c position
+		Provides auto-completion at the given cursor position. The cursor
+		position is measured in bytes from the beginning of the source code.
 
-    --clearCache
-        Instructs the server to clear out its autocompletion cache.
+	--clearCache
+		Instructs the server to clear out its autocompletion cache.
 
-    --shutdown
-        Instructs the server to shut down.
+	--shutdown
+		Instructs the server to shut down.
 
-    -IPATH
-        Instructs the server to add PATH to its list of paths searced for
-        imported modules.
+	-IPATH
+		Instructs the server to add PATH to its list of paths searced for
+		imported modules.
 
-    --port PORTNUMBER | -pPORTNUMBER
-        Uses PORTNUMBER to communicate with the server instead of the default
-        port 9166.`, programName);
+	--port PORTNUMBER | -pPORTNUMBER
+		Uses PORTNUMBER to communicate with the server instead of the default
+		port 9166.`, programName);
 }

--- a/constants.d
+++ b/constants.d
@@ -9,11 +9,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.	 If not, see <http://www.gnu.org/licenses/>.
  */
 
 module constants;

--- a/messages.d
+++ b/messages.d
@@ -9,11 +9,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.	 If not, see <http://www.gnu.org/licenses/>.
  */
 
 module messages;
@@ -23,41 +23,41 @@ module messages;
  */
 enum CompletionKind : char
 {
-    /// class names
-    className = 'c',
+	/// class names
+	className = 'c',
 
-    /// interface names
-    interfaceName = 'i',
+	/// interface names
+	interfaceName = 'i',
 
-    /// structure names
-    structName = 's',
+	/// structure names
+	structName = 's',
 
 	/// union name
 	unionName = 'u',
 
-    /// variable name
-    variableName = 'v',
+	/// variable name
+	variableName = 'v',
 
-    /// member variable
-    memberVariableName = 'm',
+	/// member variable
+	memberVariableName = 'm',
 
-    /// keyword, built-in version, scope statement
-    keyword = 'k',
+	/// keyword, built-in version, scope statement
+	keyword = 'k',
 
-    /// function or method
-    functionName = 'f',
+	/// function or method
+	functionName = 'f',
 
-    /// enum name
-    enumName = 'g',
+	/// enum name
+	enumName = 'g',
 
 	/// enum member
-    enumMember = 'e',
+	enumMember = 'e',
 
-    /// package name
-    packageName = 'P',
+	/// package name
+	packageName = 'P',
 
-    /// module name
-    moduleName = 'M',
+	/// module name
+	moduleName = 'M',
 
 	/// array
 	array = 'a',
@@ -74,16 +74,16 @@ enum CompletionKind : char
  */
 enum CompletionType : string
 {
-    /**
-     * The completion list contains a listing of identifier/kind pairs.
-     */
-    identifiers = "identifiers",
+	/**
+	 * The completion list contains a listing of identifier/kind pairs.
+	 */
+	identifiers = "identifiers",
 
-    /**
-     * The auto-completion list consists of a listing of functions and their
-     * parameters.
-     */
-    calltips = "calltips"
+	/**
+	 * The auto-completion list consists of a listing of functions and their
+	 * parameters.
+	 */
+	calltips = "calltips"
 }
 
 enum RequestKind
@@ -99,30 +99,30 @@ enum RequestKind
  */
 struct AutocompleteRequest
 {
-    /**
-     * File name used for error reporting
-     */
-    string fileName;
+	/**
+	 * File name used for error reporting
+	 */
+	string fileName;
 
 	/**
 	 * Command coming from the client
 	 */
 	RequestKind kind;
 
-    /**
-     * Paths to be searched for import files
-     */
-    string[] importPaths;
+	/**
+	 * Paths to be searched for import files
+	 */
+	string[] importPaths;
 
-    /**
-     * The source code to auto complete
-     */
-    ubyte[] sourceCode;
+	/**
+	 * The source code to auto complete
+	 */
+	ubyte[] sourceCode;
 
-    /**
-     * The cursor position
-     */
-    size_t cursorPosition;
+	/**
+	 * The cursor position
+	 */
+	size_t cursorPosition;
 }
 
 /**
@@ -130,19 +130,19 @@ struct AutocompleteRequest
  */
 struct AutocompleteResponse
 {
-    /**
-     * The autocompletion type. (Parameters or identifier)
-     */
-    string completionType;
+	/**
+	 * The autocompletion type. (Parameters or identifier)
+	 */
+	string completionType;
 
-    /**
-     * The completions
-     */
-    string[] completions;
+	/**
+	 * The completions
+	 */
+	string[] completions;
 
-    /**
-     * The kinds of the items in the completions array. Will be empty if the
-     * completion type is a function argument list.
-     */
-    char[] completionKinds;
+	/**
+	 * The kinds of the items in the completions array. Will be empty if the
+	 * completion type is a function argument list.
+	 */
+	char[] completionKinds;
 }

--- a/modulecache.d
+++ b/modulecache.d
@@ -9,11 +9,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.	 If not, see <http://www.gnu.org/licenses/>.
  */
 
 module modulecache;
@@ -71,9 +71,9 @@ struct ModuleCache
 
 	/**
 	 * Params:
-	 *     moduleName = the name of the module in "a/b.d" form
+	 *	   moduleName = the name of the module in "a/b.d" form
 	 * Returns:
-	 *     The symbols defined in the given module
+	 *	   The symbols defined in the given module
 	 */
 	static ACSymbol[] getSymbolsInModule(string moduleName)
 	{
@@ -115,10 +115,10 @@ struct ModuleCache
 
 	/**
 	 * Params:
-	 *     moduleName the name of the module being imported, in "a/b/c.d" style
+	 *	   moduleName the name of the module being imported, in "a/b/c.d" style
 	 * Returns:
-	 *     The absolute path to the file that contains the module, or null if
-	 *     not found.
+	 *	   The absolute path to the file that contains the module, or null if
+	 *	   not found.
 	 */
 	static string resolveImportLoctation(string moduleName)
 	{
@@ -148,9 +148,9 @@ private:
 
 	/**
 	 * Params:
-	 *     mod = the path to the module
+	 *	   mod = the path to the module
 	 * Returns:
-	 *     true  if the module needs to be reparsed, false otherwise
+	 *	   true	 if the module needs to be reparsed, false otherwise
 	 */
 	static bool needsReparsing(string mod)
 	{

--- a/server.d
+++ b/server.d
@@ -9,11 +9,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.	 If not, see <http://www.gnu.org/licenses/>.
  */
 
 module server;
@@ -34,11 +34,11 @@ import modulecache;
 
 version(Posix)
 {
-    enum CONFIG_FILE_PATH = "~/.config/dcd";
+	enum CONFIG_FILE_PATH = "~/.config/dcd";
 }
 else version(Windows)
 {
-    enum CONFIG_FILE_PATH = "dcd.conf";
+	enum CONFIG_FILE_PATH = "dcd.conf";
 }
 
 int main(string[] args)
@@ -143,31 +143,31 @@ int main(string[] args)
 
 string[] loadConfiguredImportDirs()
 {
-    version(Windows)
-    {
-        string fullPath = buildPath(getcwd(), CONFIG_FILE_PATH);
-    }
-    else version(Posix)
-    {
-        string fullPath = expandTilde(CONFIG_FILE_PATH);
-    }
+	version(Windows)
+	{
+		string fullPath = buildPath(getcwd(), CONFIG_FILE_PATH);
+	}
+	else version(Posix)
+	{
+		string fullPath = expandTilde(CONFIG_FILE_PATH);
+	}
 
-    if (!exists(fullPath))
-        return [];
-    File f = File(fullPath);
-    return f.byLine(KeepTerminator.no).map!(a => a.idup).filter!(a => a.exists()).array();
+	if (!exists(fullPath))
+		return [];
+	File f = File(fullPath);
+	return f.byLine(KeepTerminator.no).map!(a => a.idup).filter!(a => a.exists()).array();
 }
 
 void printHelp(string programName)
 {
-    writefln(
+	writefln(
 `
-    Usage: %s options
+	Usage: %s options
 
 options:
-    -I path
-        Includes path in the listing of paths that are searched for file imports
+	-I path
+		Includes path in the listing of paths that are searched for file imports
 
-    --port PORTNUMBER | -pPORTNUMBER
-        Listens on PORTNUMBER instead of the default port 9166.`, programName);
+	--port PORTNUMBER | -pPORTNUMBER
+		Listens on PORTNUMBER instead of the default port 9166.`, programName);
 }


### PR DESCRIPTION
I am not sure if you want to use tabs or spaces in your code. There were more 4 wide space "gaps" in the source than tabs, so I decided to go for spaces.

Reason: it throws off some editors, it looks ugly depending on the tab-width (width with tabs: 8 vs width with spaces 4), including Github.
