### PR TITLE
Parser want new memory.

### DIFF
--- a/autocomplete.d
+++ b/autocomplete.d
@@ -304,7 +304,7 @@ void setCompletions(T)(ref AutocompleteResponse response,
 			{
 				auto h = i;
 				skip();
-				Parser p;
+				Parser p = new Parser();
 				p.setTokens(tokens[h .. i].array());
 				if (!p.isSliceExpression())
 				{
@@ -320,7 +320,7 @@ void setCompletions(T)(ref AutocompleteResponse response,
 			{
 				auto h = i;
 				skip();
-				Parser p;
+				Parser p = new Parser();
 				p.setTokens(tokens[h .. i].array());
 				ACSymbol[] overloads;
 				if (p.isSliceExpression())


### PR DESCRIPTION
Is this bug ?
if compile option add -release.

```
autocomplete.d(309): Error: null dereference in function _D12autocomplete104__T14setCompletionsTS3std5range57__T11SortedRangeTAxS4stdx1d5lexer5TokenVAyaa5_61203c2062Z11SortedRangeZ14setCompletionsFKS8messages20AutocompleteResponseC9acvisitor19AutocompleteVisitorS3std5range57__T11SortedRangeTAxS4stdx1d5lexer5TokenVAyaa5_61203c2062Z11SortedRangemE8messages14CompletionTypeAyaZv
autocomplete.d(308): Error: null dereference in function _D12autocomplete104__T14setCompletionsTS3std5range57__T11SortedRangeTAxS4stdx1d5lexer5TokenVAyaa5_61203c2062Z11SortedRangeZ14setCompletionsFKS8messages20AutocompleteResponseC9acvisitor19AutocompleteVisitorS3std5range57__T11SortedRangeTAxS4stdx1d5lexer5TokenVAyaa5_61203c2062Z11SortedRangemE8messages14CompletionTypeAyaZv
autocomplete.d(326): Error: null dereference in function _D12autocomplete104__T14setCompletionsTS3std5range57__T11SortedRangeTAxS4stdx1d5lexer5TokenVAyaa5_61203c2062Z11SortedRangeZ14setCompletionsFKS8messages20AutocompleteResponseC9acvisitor19AutocompleteVisitorS3std5range57__T11SortedRangeTAxS4stdx1d5lexer5TokenVAyaa5_61203c2062Z11SortedRangemE8messages14CompletionTypeAyaZv
autocomplete.d(324): Error: null dereference in function _D12autocomplete104__T14setCompletionsTS3std5range57__T11SortedRangeTAxS4stdx1d5lexer5TokenVAyaa5_61203c2062Z11SortedRangeZ14setCompletionsFKS8messages20AutocompleteResponseC9acvisitor19AutocompleteVisitorS3std5range57__T11SortedRangeTAxS4stdx1d5lexer5TokenVAyaa5_61203c2062Z11SortedRangemE8messages14CompletionTypeAyaZv
dmd: glue.c:783: virtual void FuncDeclaration::toObjFile(int): Assertion `!vthis->csym' failed.
./build.sh: 5 line: 18674 stop                  dmd -wi -release -inline -O server.d modulecache.d actypes.d messages.d constants.d acvisitor.d autocomplete.d dscanner/stdx/d/ast.d dscanner/stdx/d/parser.d dscanner/stdx/d/lexer.d dscanner/stdx/d/entities.d dscanner/formatter.d msgpack-d/src/msgpack.d -Imsgpack-d/src -Idscanner/ -ofdcd-server
```
