### PR TITLE
Fix issue 57, and fix file open without close

### DIFF
--- a/editors/textadept/modules/dmd/dcd.lua
+++ b/editors/textadept/modules/dmd/dcd.lua
@@ -123,6 +123,7 @@ function M.autocomplete(ch)
 	p:close()
 	local tmpFile = io.open(fileName, "r")
 	local r = tmpFile:read("*a")
+	io.close(tmpFile)
 	if r ~= "\n" then
 		if r:match("^identifiers.*") then
 			showCompletionList(r)

--- a/editors/textadept/modules/dmd/init.lua
+++ b/editors/textadept/modules/dmd/init.lua
@@ -20,7 +20,7 @@ local function autocomplete()
 	_M.dcd.registerImages()
 	_M.dcd.autocomplete()
 	if not buffer:auto_c_active() then
-		_M.textadept.editing.autocomplete_word(keywords)
+		textadept.editing.autocomplete_word(keywords)
 	end
 end
 


### PR DESCRIPTION
The TextAdept module should now work with TextAdept 7.0. A bug was also
fixed regarding the TextAdept plugin where a temporary file wasn't being
closed. On Windows, this resulted in an inability to delete the file
thus my C:\ directory was being spammed with undeleted temporary files.
