### PR TITLE
Put temporary file in %TEMP% on Windows

### DIFF
--- a/editors/textadept/modules/dmd/dcd.lua
+++ b/editors/textadept/modules/dmd/dcd.lua
@@ -102,18 +102,20 @@ end
 
 function M.gotoDeclaration()
 	local fileName = os.tmpname()
-	local command = M.PATH_TO_DCD_CLIENT .. " -l -c" .. buffer.current_pos .. " > " .. fileName
 	local mode = "w"
 	if _G.WIN32 then
+		fileName = os.getenv('TEMP') .. fileName
 		mode = "wb"
 	end
+	local command = M.PATH_TO_DCD_CLIENT .. " -l -c" .. buffer.current_pos ..
+	                " > \"" .. fileName .. "\""
 	local p = io.popen(command, mode)
 	p:write(buffer:get_text())
 	p:flush()
 	p:close()
 	local tmpFile = io.open(fileName, "r")
 	local r = tmpFile:read("*a")
-	io.close(tmpFile)
+	tmpFile:close()
 	if r ~= "Not found\n" then
 		path, position = r:match("^(.-)\t(%d+)")
 		if (path ~= nil and position ~= nil) then
@@ -139,18 +141,20 @@ end)
 function M.autocomplete(ch)
 	if buffer:get_lexer() ~= "dmd" then return end
 	local fileName = os.tmpname()
-	local command = M.PATH_TO_DCD_CLIENT .. " -c" .. buffer.current_pos .. " > " .. fileName
 	local mode = "w"
 	if _G.WIN32 then
+		fileName = os.getenv('TEMP') .. fileName
 		mode = "wb"
 	end
+	local command = M.PATH_TO_DCD_CLIENT .. " -c" .. buffer.current_pos ..
+	                " > \"" .. fileName .. "\""
 	local p = io.popen(command, mode)
 	p:write(buffer:get_text())
 	p:flush()
 	p:close()
 	local tmpFile = io.open(fileName, "r")
 	local r = tmpFile:read("*a")
-	io.close(tmpFile)
+	tmpFile:close()
 	if r ~= "\n" then
 		if r:match("^identifiers.*") then
 			showCompletionList(r)


### PR DESCRIPTION
May potentially fix issue 76, as the filenames returned by os.tmpname()
were going into my C drive root directory due to the \ in the front.
I suspect that some people may not have user permissions to read/write
to the root of their C drive. I don't know why os.tmpname() does not
give a file in %TEMP% on Windows like it does on Linux. Maybe it's a
bug.
