### PR TITLE
Add doc and symbol location support to vim plugin

### DIFF
--- a/editors/vim/README.md
+++ b/editors/vim/README.md
@@ -56,6 +56,12 @@ Use `DCDclearCache` to clear the DCD server cache.
 When the server is running, use `CTRL`+`x` `CTRL`+`o` in a D buffer to use DCD
 completion.
 
+When the server is running, use the `DCDdoc` to print the doc-string of symbol
+under the cursor.
+
+When the server is running, use the `DCDsymbolLocation` to print jump to the
+declaration of the symbol under the cursor.
+
 Conflicts
 =========
 This plugin conflicts with the DScanner plugin, as both use the `dcomplete`

--- a/editors/vim/ftplugin/d.vim
+++ b/editors/vim/ftplugin/d.vim
@@ -12,3 +12,6 @@ command! -buffer -nargs=? DCDonCurrentBufferPosition echo dcomplete#runDCDOnCurr
 command! -buffer DCDstopServer DCD --shutdown
 command! -buffer -nargs=+ -complete=dir DCDaddPath execute 'DCD '.dcomplete#globImportPath([<f-args>])
 command! -buffer DCDclearCache DCD --clearCache
+
+command! -buffer DCDdoc DCDonCurrentBufferPosition --doc
+command! -buffer DCDsymbolLocation call dcomplete#runDCDtoJumpToSymbolLocation()


### PR DESCRIPTION
`--doc` is supported with the `DCDdoc` command. I wanted to use the `K` key, but sadly it has to run an external program with the identifier under the cursor - I can't feed the current buffer text and the byte position to it...

`--symbolLocation` is supported with the `DCDsymbolLocation` command. It jumps to the declaration if DCD can find one.

I've also fixed [a bug where "free" symbols(=not after dot and not parenthesis) couldn't be autocompleted](http://forum.dlang.org/thread/utnxjyetwcpnpegqyrdd@forum.dlang.org#post-szzszkyivairvkgwlqtl:40forum.dlang.org).
