### PR TITLE
Fix issue #138: Make sure that RequestKind.addImport carries on analysin...

### DIFF
--- a/client.d
+++ b/client.d
@@ -225,6 +225,8 @@ AutocompleteResponse getResponse(TcpSocket socket)
 	auto bytesReceived = socket.receive(buffer);
 	if (bytesReceived == Socket.ERROR)
 		throw new Exception("Incorrect number of bytes received");
+	if (bytesReceived == 0)
+		throw new Exception("Server closed the connection, 0 bytes received");
 	AutocompleteResponse response;
 	msgpack.unpack(buffer[0..bytesReceived], response);
 	return response;

--- a/server.d
+++ b/server.d
@@ -157,7 +157,7 @@ int main(string[] args)
 		}
 		if (request.kind & RequestKind.addImport)
 			ModuleCache.addImportPaths(request.importPaths);
-		else if (request.kind & RequestKind.autocomplete)
+		if (request.kind & RequestKind.autocomplete)
 		{
 			Log.info("Getting completions");
 			AutocompleteResponse response = complete(request);


### PR DESCRIPTION
The "else if" was causing the importPath request to work then ignored anything else. The server closed the connection with the client, who tried to unpack the 0-byte response, generating the exception in the bug report.
