### PR TITLE
Fix issue #135: 'Emacs temporary files cause DCD to crash'. dcd-server n...

### DIFF
--- a/modulecache.d
+++ b/modulecache.d
@@ -101,6 +101,8 @@ struct ModuleCache
 		{
 			foreach (fileName; dirEntries(path, "*.{d,di}", SpanMode.depth))
 			{
+				import std.path: baseName;
+				if(fileName.baseName.startsWith(".#")) continue;
 				getSymbolsInModule(fileName);
 			}
 		}


### PR DESCRIPTION
dcd-server now ignores files starting with '.#'
