### PR TITLE
use position-bytes function to get the byte offset

### DIFF
--- a/editors/emacs/ac-dcd.el
+++ b/editors/emacs/ac-dcd.el
@@ -23,8 +23,9 @@
 
 (require 'auto-complete)
 (require 'rx)
-(require 'yasnippet)
+(require 'yasnippet nil t)
 (require 'eshell)
+
 (defcustom ac-dcd-executable
   "dcd-client"
   "Location of dcd-client executable."
@@ -167,7 +168,7 @@ If you want to restart server, use `ac-dcd-init-server' instead."
 (defsubst ac-dcd-cursor-position ()
   "Get cursor position to pass to dcd-client.
 TODO: multi byte character support"
-  (point))
+  (position-bytes (point)))
 
 (defsubst ac-dcd-build-complete-args (pos)
   (list


### PR DESCRIPTION
The position-bytes function is the correct way to get byte offset for an
UTF-8 encoded source file. Probably, it still won't work for UTF-16 and
UTF-32, but at least it fixes the UTF-8.

Also, this pull makes the yasnippet dependency optional (which it really is).
