### PR TITLE
Deprecate the Vim plugin in favor of Dutyl

### DIFF
--- a/editors/vim/README.md
+++ b/editors/vim/README.md
@@ -1,3 +1,9 @@
+This plugin is deprecated in favor of [the Dutyl
+plugin](https://github.com/idanarye/vim-dutyl), that can set the import paths
+from other sources.
+
+----------------------
+
 A plugin for using DCD with vim.
 
 Tested on Linux (and a bit on Windows)


### PR DESCRIPTION
My new Vim plugin, [Dutyl](https://github.com/idanarye/vim-dutyl), can operate DCD for autocompletion. Dutyl uses DUB to feed the import paths to DCD, so it's preferable to this plugin.
