### PR TITLE
Fix issue #165: Emacs temporary files cause DCD to crash for import auto...

### DIFF
--- a/src/autocomplete.d
+++ b/src/autocomplete.d
@@ -861,6 +861,8 @@ void setImportCompletions(T)(T tokens, ref AutocompleteResponse response)
 
 		foreach (string name; dirEntries(p, SpanMode.shallow))
 		{
+                        import std.path: baseName;
+                        if (name.baseName.startsWith(".#")) continue;
 			if (isFile(name) && (name.endsWith(".d") || name.endsWith(".di")))
 			{
 				response.completions ~= name.baseName(".d").baseName(".di");


### PR DESCRIPTION
Import autocompletion causes dcd-server to crash.

This is nearly the same fix as for issue #135, and it might be better to call a function that does this whenever checking to see if something is a file. Since that would entail quite some refactoring and maybe reorganising the code, I didn't do it.
