### PR TITLE
Issue 170: Update build.bat to use dcd_version.d

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -4,6 +4,7 @@ dmd^
  src\client.d^
  src\messages.d^
  src\stupidlog.d^
+ src\dcd_version.d^
  msgpack-d/src/msgpack.d^
  -Imsgpack-d/src^
  -release -inline -O -wi^
@@ -23,6 +24,7 @@ dmd^
  src\server.d^
  src\stupidlog.d^
  src\string_interning.d^
+ src\dcd_version.d^
  libdparse/src/std/d/ast.d^
  libdparse/src/std/d/entities.d^
  libdparse/src/std/d/lexer.d^


### PR DESCRIPTION
The src/dcd_version.d file is missing from build.bat, breaking Windows
client and server builds.
