### PR TITLE
Find usages of symbol in current file

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,27 @@ in place of a file being edited.)
 /usr/include/dmd/phobos/std/conv.d  f   9494
 ```
 
+## Find usage of symbol at cursor
+```dcd-client --localUsage -c 123```
+
+The "--localUsage" or "-u" flags cause the client to instruct the server
+to return the path to the file and the byte offset of the declaration and byte
+offsets for all symbol usages in current source code.
+
+#### Output format
+A line containing the output as described in [Find declaration of symbol at cursor](#find-declaration-of-symbol-at-cursor) followed
+by the symbol name and the symbol kind separated by tab character.
+Then the offsets of symbol usage presented in the current source code will be printed, one per line.
+
+#### Example output
+```
+stdin	92
+a	v
+92
+133
+148
+```
+
 #Server
 The server must be running for the DCD client to provide autocomplete information.
 In future versions the client may start the server if it is not running, but for

--- a/src/client.d
+++ b/src/client.d
@@ -46,6 +46,7 @@ int main(string[] args)
 	bool doc;
 	bool query;
 	bool printVersion;
+	bool localUsage;
 	string search;
 
 	try
@@ -54,6 +55,7 @@ int main(string[] args)
 			"port|p", &port, "help|h", &help, "shutdown", &shutdown,
 			"clearCache", &clearCache, "symbolLocation|l", &symbolLocation,
 			"doc|d", &doc, "query|q", &query, "search|s", &search,
+			"localUsage|u", &localUsage,
 			"version", &printVersion);
 	}
 	catch (ConvException e)
@@ -177,6 +179,8 @@ int main(string[] args)
 		request.kind |= RequestKind.doc;
 	else if(search)
 		request.kind |= RequestKind.search;
+	else if (localUsage)
+		request.kind |= RequestKind.localUsage;
 	else
 		request.kind |= RequestKind.autocomplete;
 
@@ -194,6 +198,8 @@ int main(string[] args)
 		printDocResponse(response);
 	else if (search !is null)
 		printSearchResponse(response);
+	else if (localUsage)
+		printLocalUsageResponse(response);
 	else
 		printCompletionResponse(response);
 
@@ -239,6 +245,10 @@ Options:
     --search | -s symbolName
         Searches for symbolName in both stdin / the given file name as well as
         others files cached by the server.
+
+    --localUsage | -u
+	Finds the usages of the symbol at the cursor location in the current
+	source code.
 
     --query | -q
         Query the server statis. Returns 0 if the server is running. Returns
@@ -300,7 +310,7 @@ void printDocResponse(AutocompleteResponse response)
 		writeln(doc);
 }
 
-void printLocationResponse(AutocompleteResponse response)
+void printLocationResponse(const AutocompleteResponse response)
 {
 	if (response.symbolFilePath is null)
 		writeln("Not found");
@@ -338,5 +348,16 @@ void printSearchResponse(const AutocompleteResponse response)
 	{
 		writefln("%s\t%s\t%s", response.completions[i], response.completionKinds[i],
 			response.locations[i]);
+	}
+}
+
+void printLocalUsageResponse(const AutocompleteResponse response)
+{
+	printLocationResponse(response);
+	if (response.completions.length && response.completionKinds.length)
+		writefln("%s\t%s", response.completions.front(), response.completionKinds.front());
+	foreach (loc; response.locations)
+	{
+		writeln(loc);
 	}
 }

--- a/src/messages.d
+++ b/src/messages.d
@@ -117,25 +117,27 @@ enum CompletionType : string
 /**
  * Request kind
  */
-enum RequestKind : ubyte
+enum RequestKind : ushort
 {
-	uninitialized =  0b00000000,
+	uninitialized =  0b000000000,
 	/// Autocompletion
-	autocomplete =   0b00000001,
+	autocomplete =   0b000000001,
 	/// Clear the completion cache
-	clearCache =     0b00000010,
+	clearCache =     0b000000010,
 	/// Add import directory to server
-	addImport =      0b00000100,
+	addImport =      0b000000100,
 	/// Shut down the server
-	shutdown =       0b00001000,
+	shutdown =       0b000001000,
 	/// Get declaration location of given symbol
-	symbolLocation = 0b00010000,
+	symbolLocation = 0b000010000,
 	/// Get the doc comments for the symbol
-	doc =            0b00100000,
+	doc =            0b000100000,
 	/// Query server status
-	query =	         0b01000000,
+	query =	         0b001000000,
 	/// Search for symbol
-	search =         0b10000000,
+	search =         0b010000000,
+	/// Local symbol usage
+	localUsage =     0b100000000,
 }
 
 /**

--- a/src/server.d
+++ b/src/server.d
@@ -221,6 +221,19 @@ int main(string[] args)
 			ubyte[] responseBytes = msgpack.pack(response);
 			s.send(responseBytes);
 		}
+		else if (request.kind & RequestKind.localUsage)
+		{
+			try
+			{
+				AutocompleteResponse response = findLocalUsage(request);
+				ubyte[] responseBytes = msgpack.pack(response);
+				s.send(responseBytes);
+			}
+			catch (Exception e)
+			{
+				Log.error("Could not get symbol usage ", e.msg);
+			}
+		}
 		Log.info("Request processed in ", requestWatch.peek().to!("msecs", float), " milliseconds");
 	}
 	return 0;


### PR DESCRIPTION
It can be useful to get all the usages of the symbol at cursor in the current file, e.g. for its highlighting or local variables renaming.
