### PR TITLE
Refactor travis config to include dub build and ldc.

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+if [[ $BUILD == dub ]]; then
+    mkdir bin
+
+    dub build --build=release --config=client
+    dub build --build=release --config=server
+
+    mv dcd-client ./bin
+    mv dcd-server ./bin
+elif [[ $DC == ldc2 ]]; then
+    git submodule update --init --recursive
+    make ldc -j2
+else
+    git submodule update --init --recursive
+    make debug -j2
+fi
+
+cd tests && ./run_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,17 @@
 sudo: false
 language: d
-script:
-    - git submodule update --init --recursive
-    - make debug -j2
-    - cd tests && ./run_tests.sh
+d:
+  - dmd-beta
+  - dmd
+  - ldc
+
+os:
+  - linux
+# TODO, some bug in OSX for the server that causes it to fail
+#  - osx
+
+env:
+  - BUILD=
+  - BUILD=dub
+
+script: ./.travis.sh

--- a/dub.json
+++ b/dub.json
@@ -7,7 +7,7 @@
   ],
   "license": "GPL-3.0",
   "dependencies": {
-    "dsymbol": "~>0.2.0",
+    "dsymbol": "~>0.2.1-alpha.2",
     "libdparse": "~>0.7.1-beta.1",
     "msgpack-d": "~>1.0.0-beta.3"
   },


### PR DESCRIPTION
The dub has two test failures which I'll look into, and the OSX version gets `std.socket.SocketOSException@std/socket.d(2778): Unable to connect socket: No such file or directory` sometimes for the tests. Seems to be hit or miss. Don't have a mac so can't test it, might end up just removing osx from travis.