### PR TITLE
support for the getLinkage trait

### DIFF
--- a/src/common/constants.d
+++ b/src/common/constants.d
@@ -54,6 +54,7 @@ immutable string[] traits = [
 	"getAliasThis",
 	"getAttributes",
 	"getFunctionAttributes",
+	"getLinkage",
 	"getMember",
 	"getOverloads",
 	"getPointerBitmap",


### PR DESCRIPTION
There's no emergency, needed after next dmd release.