### PR TITLE
fix #319 - server crash when an import path contains a folder that's not accessible

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -7,7 +7,7 @@
   ],
   "license": "GPL-3.0",
   "dependencies": {
-    "dsymbol": "~>0.2.1-alpha.2",
+    "dsymbol": "~>0.2.1",
     "libdparse": "~>0.7.1-beta.4",
     "msgpack-d": "~>1.0.0-beta.3"
   },

--- a/src/server/autocomplete.d
+++ b/src/server/autocomplete.d
@@ -681,7 +681,7 @@ void setImportCompletions(T)(T tokens, ref AutocompleteResponse response,
 
 			found = true;
 
-			foreach (string name; dirEntries(p, SpanMode.shallow))
+			try foreach (string name; dirEntries(p, SpanMode.shallow))
 			{
 				import std.path: baseName;
 				if (name.baseName.startsWith(".#"))
@@ -705,6 +705,7 @@ void setImportCompletions(T)(T tokens, ref AutocompleteResponse response,
 					}
 				}
 			}
+			catch(FileException){}
 		}
 	}
 	if (!found)

--- a/src/server/autocomplete.d
+++ b/src/server/autocomplete.d
@@ -705,7 +705,10 @@ void setImportCompletions(T)(T tokens, ref AutocompleteResponse response,
 					}
 				}
 			}
-			catch(FileException){}
+			catch(FileException)
+			{
+				warning("Cannot access import path: ", importPath);
+			}
 		}
 	}
 	if (!found)


### PR DESCRIPTION
I've verified locally, i don't see how to check this easily online. Also Cybershadow can't test anymore with the project that led to the report.

So to check:

- choose a repo with packages (sub folder containing sources).
- in sudo forbid access to one of the package.
- start dcd / add the repo to the import
- try to get import completion (`import.stuff.`) for the package that matches to the folder previously chmod-ed

after the fix no crash.
