### PR TITLE
Provide backlog for socket.listen()

### DIFF
--- a/src/server/main.d
+++ b/src/server/main.d
@@ -156,7 +156,7 @@ int main(string[] args)
 			info("Listening at ", socketFile);
 		}
 	}
-	socket.listen(0);
+	socket.listen(32);
 
 	scope (exit)
 	{


### PR DESCRIPTION
`listen(0)` in general means that you can't connect to the server at all. That it still works is at least in parts due to SYN cookies being enabled in most Linux systems. These allow connections even if an attacker spams the server with unacknowledged connection requests thereby filling up the backlog. Being behind a firewall/router I have this disabled in the kernel and witness the 'proper' socket behavior: The client waits for the server to make room in its size 0 backlog until the TCP timeout happens.
Both enabling SYN cookies and raising the backlog to at least 1 makes it work. Since DCD works purely on the loopback network which seems to accept connections synchronous on Linux at least, a value of 1 is probably all that's technically required, but some larger number (32) wont do any harm.