### PR TITLE
Updated old URLs - Changed Hackerpilot/DCD to dlang-community/DCD

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,8 +6,8 @@
 	url = https://github.com/economicmodeling/containers.git
 [submodule "libdparse"]
 	path = libdparse
-	url = https://github.com/Hackerpilot/libdparse.git
+	url = https://github.com/dlang-community/libdparse.git
 	branch = master
 [submodule "dsymbol"]
 	path = dsymbol
-	url = https://github.com/Hackerpilot/dsymbol.git
+	url = https://github.com/dlang-community/dsymbol.git

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ calculating autocomplete information, and sending it back to the client.
 This program is reasonably stable. Please report problems on the Github issue
 tracker. Please be sure that you have read the documentation before filing an
 issue. (If you want to help your bug to get fixed faster, you can create a
-[test case](https://github.com/Hackerpilot/DCD/wiki/Testing) that helps isolate
+[test case](https://github.com/dlang-community/DCD/wiki/Testing) that helps isolate
 the issue.)
 
 * Working:
@@ -44,7 +44,7 @@ the issue.)
 ### General
 1. Install a recent D compiler. DCD is tested with DMD 2.068.2, DMD 2.069.0-rc2, and LDC 0.16 (Do not use DMD 2.068.1)
 1. Follow the directions listed below for Homebrew, Git + Make, or Dub, depending on how you would like to build DCD.
-1. Configure your text editor to call the dcd-client program. See the [wiki](https://github.com/Hackerpilot/DCD/wiki/IDEs-and-Editors-with-DCD-support) for information on configuring your specific editor.
+1. Configure your text editor to call the dcd-client program. See the [wiki](https://github.com/dlang-community/DCD/wiki/IDEs-and-Editors-with-DCD-support) for information on configuring your specific editor.
 1. Start the dcd-server program before editing code. (Unless, of course, your editor's plugin handles this for you)
 
 ### Git + Make

--- a/man1/dcd-client.1
+++ b/man1/dcd-client.1
@@ -1,4 +1,4 @@
-.TH dcd-client 1 "Feb 13 2017" "" https://github.com/Hackerpilot/DCD
+.TH dcd-client 1 "Feb 13 2017" "" https://github.com/dlang-community/DCD
 .SH NAME
 dcd-client \- autocompletion client for the D programming language
 .PD
@@ -102,7 +102,7 @@ Written by Brian Schott (@Hackerpilot on Github)
 .PD
 .SH BUGS
 Please use the issue tracker located at
-.UR https://github.com/Hackerpilot/DCD/issues
+.UR https://github.com/dlang-community/DCD/issues
 .UE
 .SH SEE ALSO
 \fBdcd-server\fP(1)

--- a/man1/dcd-server.1
+++ b/man1/dcd-server.1
@@ -1,4 +1,4 @@
-.TH dcd-server 1 Feb 13 2017 "" https://github.com/Hackerpilot/DCD
+.TH dcd-server 1 Feb 13 2017 "" https://github.com/dlang-community/DCD
 .SH NAME
 dcd-server \- autocompletion server for the D programming language
 .PD
@@ -103,7 +103,7 @@ Written by Brian Schott (@Hackerpilot on Github)
 .PD
 .SH BUGS
 Please use the issue tracker located at
-.UR https://github.com/Hackerpilot/DCD/issues
+.UR https://github.com/dlang-community/DCD/issues
 .UE
 .SH SEE ALSO
 \fBdcd-client\fP(1)


### PR DESCRIPTION
I noticed that in some places the url was still github.com/Hackerpilot/DCD, I updated it to be dlang-community/DCD.