### PR TITLE
update libdparse to prevent case of OutOfMem

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -8,7 +8,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     "dsymbol": "~>0.2.8",
-    "libdparse": "~>0.7.1",
+    "libdparse": ">=0.7.2-alpha.2",
     "msgpack-d": "~>1.0.0-beta.3"
   },
   "versions": ["built_with_dub"],


### PR DESCRIPTION
Related to https://github.com/dlang-community/libdparse/issues/176