### PR TITLE
fix #445 - Cannot build via dub on windows

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -26,7 +26,6 @@
       "name": "client",
       "targetType": "executable",
       "targetName": "dcd-client",
-      "mainSourceFile": "src/dcd/client/client.d",
       "excludedSourceFiles": [
         "src/dcd/server/*"
       ]
@@ -35,7 +34,6 @@
       "name": "server",
       "targetType": "executable",
       "targetName": "dcd-server",
-      "mainSourceFile": "src/dcd/server/server.d",
       "excludedSourceFiles": [
         "src/dcd/client/*"
       ]


### PR DESCRIPTION
checked for back compat back to2.076.1, which is the version i still use for prebuild Coedit DCD because of another bug.