### PR TITLE
Moving dub binaries to bin/

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -3,13 +3,8 @@
 set -e
 
 if [[ $BUILD == dub ]]; then
-    mkdir bin
-
     dub build --build=release --config=client
     dub build --build=release --config=server
-
-    mv dcd-client ./bin
-    mv dcd-server ./bin
 elif [[ $DC == ldc2 ]]; then
     git submodule update --init --recursive
     make ldc -j2

--- a/dub.json
+++ b/dub.json
@@ -25,6 +25,7 @@
     {
       "name": "client",
       "targetType": "executable",
+	  "targetPath": "bin/",
       "targetName": "dcd-client",
       "excludedSourceFiles": [
         "src/dcd/server/*"
@@ -33,6 +34,7 @@
     {
       "name": "server",
       "targetType": "executable",
+	  "targetPath": "bin/",
       "targetName": "dcd-server",
       "excludedSourceFiles": [
         "src/dcd/client/*"


### PR DESCRIPTION
To get dub build in line with make and build.bat, binary output should end up in bin/.