### PR TITLE
Make the test_runner more stable on the Project Tester - fix #455

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -26,13 +26,16 @@ echo "Shutting down currently-running server..."
 
 for socket in unix tcp; do
 	# allow some time for server to shutdown
-	sleep 1s;
+	sleep 0.5s;
 
 	echo "Running tests for $socket sockets"
 
 	# Start up the server
 	echo "Starting server..."
 	startServer
+
+	# make sure the server is up and running
+	sleep 0.5s
 
 	# Run tests
 	for testCase in tc*; do


### PR DESCRIPTION
Should prevent the failures seen in https://github.com/dlang-community/DCD/issues/455 and allow to re-enable DCD at the project tester.

https://github.com/dlang/ci/pull/204