### PR TITLE
[trivial] Fix Travis deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
         file: bin/dcd-*.tar.gz
         skip_cleanup: true
         on:
-          repo: dlang-community/dcd
+          repo: dlang-community/DCD
           tags: true
     - stage: GitHub Release
       #if: tag IS present
@@ -45,7 +45,7 @@ jobs:
         file: bin/dcd-*.tar.gz
         skip_cleanup: true
         on:
-          repo: dlang-community/dcd
+          repo: dlang-community/DCD
           tags: true
     - stage: GitHub Release
       #if: tag IS present
@@ -66,7 +66,7 @@ jobs:
           file: bin/dcd-.*.zip
           skip_cleanup: true
           on:
-            repo: dlang-community/dcd
+            repo: dlang-community/DCD
             tags: true
 stages:
   - name: test


### PR DESCRIPTION
Apparentely casing is important as it failed with:

> Skipping a deployment with the releases provider because this repo's name does not match one specified in .travis.yml's deploy.on.repo: dlang-community/dcd

https://travis-ci.org/dlang-community/DCD/jobs/371909754