### PR TITLE
fix #419 - Random server freezes when scanning imports and if built using dmd for win32 >= 2.077

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -7,7 +7,7 @@
   ],
   "license": "GPL-3.0",
   "dependencies": {
-    "dsymbol": "~>0.3.1",
+    "dsymbol": "~>0.3.2",
     "libdparse": "~>0.8.1",
     "msgpack-d": "~>1.0.0-beta.3",
     "stdx-allocator": "~>2.77.0"


### PR DESCRIPTION
ping @andre2007, if you want to confirm that the fix is working.