### PR TITLE
Remove dmd-beta and dmd-nightly from TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: d
 d:
-  - dmd-nightly
-  - dmd-beta
   - dmd
   - ldc-beta
   - ldc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,18 +2,6 @@ platform: x64
 environment:
  matrix:
   - DC: dmd
-    DVersion: nightly
-    arch: x64
-  - DC: dmd
-    DVersion: nightly
-    arch: x86
-  - DC: dmd
-    DVersion: beta
-    arch: x64
-  - DC: dmd
-    DVersion: beta
-    arch: x86
-  - DC: dmd
     DVersion: stable
     arch: x64
   - DC: dmd


### PR DESCRIPTION
- dmd-nightly is already done by the D project tester.
- dmd-beta is most of the time useless because the beta is older than the latest dmd