### PR TITLE
Fix #506

### DIFF
--- a/src/dcd/client/client.d
+++ b/src/dcd/client/client.d
@@ -396,7 +396,7 @@ void printCompletionResponse(ref const AutocompleteResponse response, bool exten
 void printSearchResponse(const AutocompleteResponse response)
 {
 	foreach(ref completion; response.completions)
-		writeln(makeTabSeparated(completion.identifier, "" ~ completion.kind, completion.symbolLocation.to!string));
+		writeln(makeTabSeparated(completion.symbolFilePath, "" ~ completion.kind, completion.symbolLocation.to!string));
 }
 
 void printLocalUse(const AutocompleteResponse response)

--- a/tests/tc062/.gitignore
+++ b/tests/tc062/.gitignore
@@ -1,0 +1,1 @@
+/expected1.txt

--- a/tests/tc062/file.d
+++ b/tests/tc062/file.d
@@ -1,0 +1,1 @@
+void funcName() {}

--- a/tests/tc062/run.sh
+++ b/tests/tc062/run.sh
@@ -1,0 +1,7 @@
+set -e
+set -u
+
+../../bin/dcd-client $1 -I $(pwd)
+echo | ../../bin/dcd-client $1 --search funcName > actual1.txt
+echo -e "$(pwd)/file.d\tf\t5" > expected1.txt
+diff actual1.txt expected1.txt


### PR DESCRIPTION
fixes #506 and adds a unittest for --search so this doesn't happen again.