### PR TITLE
fix issue 557 - Module name completion should not complete anything

### DIFF
--- a/src/dcd/server/autocomplete/complete.d
+++ b/src/dcd/server/autocomplete/complete.d
@@ -77,10 +77,11 @@ public AutocompleteResponse complete(const AutocompleteRequest request,
 	if (tokenArray.length >= 3 && tokenArray[0] == tok!"module" && beforeTokens.length &&
 		(beforeTokens[$-1] == tok!"." || dotId))
 	{
-		const upper = tokenArray.countUntil!(a => a.type == tok!";");
-		bool isSame = true;
+		const upper = tokenArray.countUntil!(a => a.type == tok!";" &&
+												  a.index < beforeTokens[$-1].index);
+		bool isSame = upper != -1;
 		// enough room for the module decl and the fqn...
-		if (upper != -1 && beforeTokens.length >= upper * 2)
+		if (isSame && beforeTokens.length >= upper * 2)
 			foreach (immutable i; 0 .. upper)
 		{
 			const j = beforeTokens.length - upper + i - 1 - ubyte(dotId);

--- a/tests/tc_currmod_fqn/file3.d
+++ b/tests/tc_currmod_fqn/file3.d
@@ -1,0 +1,1 @@
+module foo.test; int x;

--- a/tests/tc_currmod_fqn/run.sh
+++ b/tests/tc_currmod_fqn/run.sh
@@ -5,3 +5,5 @@ set -u
 diff actual1.txt expected1.txt
 ../../bin/dcd-client $1 file2.d -c46 > actual2.txt
 diff actual2.txt expected2.txt
+../../bin/dcd-client $1 file3.d -c11 > actual3.txt
+diff actual3.txt expected3.txt


### PR DESCRIPTION
It was due to the `isSame` default value, never invalidated when the loop didn't start at all.