### PR TITLE
Extended mode ditto comment support

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -7,7 +7,7 @@
   ],
   "license": "GPL-3.0",
   "dependencies": {
-    "dsymbol": "~>0.5.5",
+    "dsymbol": "~>0.5.6",
     "libdparse": "~>0.10.10",
     "msgpack-d": "~>1.0.0-beta.7",
     "stdx-allocator": "~>2.77.5"

--- a/src/dcd/server/autocomplete/doc.d
+++ b/src/dcd/server/autocomplete/doc.d
@@ -53,8 +53,16 @@ public AutocompleteResponse getDoc(const AutocompleteRequest request,
 		warning("Could not find symbol");
 	else
 	{
-		foreach(ref symbol; stuff.symbols.filter!(a => !a.doc.empty && !a.doc.ditto))
+		// first symbol allows ditto if it's the first documentation,
+		// because then it takes documentation from a symbol with different name
+		// which isn't inside the stuff.symbols range.
+		bool firstSymbol = true;
+		foreach(ref symbol; stuff.symbols.filter!(a => !a.doc.empty))
 		{
+			if (!firstSymbol && symbol.doc.ditto)
+				continue;
+			firstSymbol = false;
+
 			AutocompleteResponse.Completion c;
 			c.documentation = symbol.doc;
 			response.completions ~= c;

--- a/src/dcd/server/autocomplete/doc.d
+++ b/src/dcd/server/autocomplete/doc.d
@@ -53,16 +53,7 @@ public AutocompleteResponse getDoc(const AutocompleteRequest request,
 		warning("Could not find symbol");
 	else
 	{
-		bool isDitto(string s)
-		{
-			import std.uni : icmp;
-			if (s.length > 5)
-				return false;
-			else
-				return s.icmp("ditto") == 0;
-		}
-
-		foreach(ref symbol; stuff.symbols.filter!(a => !a.doc.empty && !isDitto(a.doc)))
+		foreach(ref symbol; stuff.symbols.filter!(a => !a.doc.empty && !a.doc.ditto))
 		{
 			AutocompleteResponse.Completion c;
 			c.documentation = symbol.doc;

--- a/tests/tc_ditto_scopes/expected1.txt
+++ b/tests/tc_ditto_scopes/expected1.txt
@@ -1,0 +1,1 @@
+documentation for a; b has no documentation

--- a/tests/tc_ditto_scopes/expected3.txt
+++ b/tests/tc_ditto_scopes/expected3.txt
@@ -1,0 +1,1 @@
+documentation for c and d\nmore documentation for c and d

--- a/tests/tc_ditto_scopes/expected4.txt
+++ b/tests/tc_ditto_scopes/expected4.txt
@@ -1,0 +1,1 @@
+documentation for c and d\nmore documentation for c and d

--- a/tests/tc_ditto_scopes/expected5.txt
+++ b/tests/tc_ditto_scopes/expected5.txt
@@ -1,0 +1,1 @@
+documentation for e and f

--- a/tests/tc_ditto_scopes/expected6.txt
+++ b/tests/tc_ditto_scopes/expected6.txt
@@ -1,0 +1,1 @@
+documentation for e and f

--- a/tests/tc_ditto_scopes/expected7.txt
+++ b/tests/tc_ditto_scopes/expected7.txt
@@ -1,0 +1,1 @@
+documentation for g\nmore documentation for g

--- a/tests/tc_ditto_scopes/expected8.1.txt
+++ b/tests/tc_ditto_scopes/expected8.1.txt
@@ -1,0 +1,1 @@
+documentation for C.x

--- a/tests/tc_ditto_scopes/expected8.2.txt
+++ b/tests/tc_ditto_scopes/expected8.2.txt
@@ -1,0 +1,1 @@
+documentation for C.y and C.z

--- a/tests/tc_ditto_scopes/expected8.3.txt
+++ b/tests/tc_ditto_scopes/expected8.3.txt
@@ -1,0 +1,1 @@
+documentation for C.y and C.z

--- a/tests/tc_ditto_scopes/expected8.txt
+++ b/tests/tc_ditto_scopes/expected8.txt
@@ -1,0 +1,1 @@
+documentation for C and D

--- a/tests/tc_ditto_scopes/expected9.txt
+++ b/tests/tc_ditto_scopes/expected9.txt
@@ -1,0 +1,1 @@
+documentation for C and D

--- a/tests/tc_ditto_scopes/file.d
+++ b/tests/tc_ditto_scopes/file.d
@@ -1,0 +1,27 @@
+int a;  /// documentation for a; b has no documentation
+int b;
+
+/** documentation for c and d */
+/** more documentation for c and d */
+int c;
+/** ditto */
+int d;
+
+/** documentation for e and f */ int e;
+int f;  /// ditto
+
+/** documentation for g */
+int g; /// more documentation for g
+
+/// documentation for C and D
+class C
+{
+    int x; /// documentation for C.x
+
+    /** documentation for C.y and C.z */
+    int y;
+    int z; /// ditto
+}
+
+/// ditto
+class D { }

--- a/tests/tc_ditto_scopes/run.sh
+++ b/tests/tc_ditto_scopes/run.sh
@@ -1,0 +1,39 @@
+set -e
+set -u
+
+../../bin/dcd-client $1 file.d -d -c5 > actual1.txt
+diff actual1.txt expected1.txt
+
+../../bin/dcd-client $1 file.d -d -c61 > actual2.txt
+diff actual2.txt expected2.txt
+
+../../bin/dcd-client $1 file.d -d -c140 > actual3.txt
+diff actual3.txt expected3.txt
+
+../../bin/dcd-client $1 file.d -d -c160 > actual4.txt
+diff actual4.txt expected4.txt
+
+../../bin/dcd-client $1 file.d -d -c201 > actual5.txt
+diff actual5.txt expected5.txt
+
+../../bin/dcd-client $1 file.d -d -c208 > actual6.txt
+diff actual6.txt expected6.txt
+
+../../bin/dcd-client $1 file.d -d -c254 > actual7.txt
+diff actual7.txt expected7.txt
+
+../../bin/dcd-client $1 file.d -d -c323 > actual8.txt
+diff actual8.txt expected8.txt
+
+../../bin/dcd-client $1 file.d -d -c335 > actual8.1.txt
+diff actual8.1.txt expected8.1.txt
+
+../../bin/dcd-client $1 file.d -d -c414 > actual8.2.txt
+diff actual8.2.txt expected8.2.txt
+
+../../bin/dcd-client $1 file.d -d -c425 > actual8.3.txt
+diff actual8.3.txt expected8.3.txt
+
+../../bin/dcd-client $1 file.d -d -c457 > actual9.txt
+diff actual9.txt expected9.txt
+

--- a/tests/tc_extended_ditto/expected1.txt
+++ b/tests/tc_extended_ditto/expected1.txt
@@ -1,0 +1,3 @@
+identifiers
+foo	f	void foo()	stdin 26	my documentation
+foo	f	void foo(int i)	stdin 49	my documentation

--- a/tests/tc_extended_ditto/file.d
+++ b/tests/tc_extended_ditto/file.d
@@ -1,0 +1,9 @@
+/// my documentation
+void foo(){}
+/// ditto
+void foo(int i){}
+
+void test()
+{
+	fo
+}

--- a/tests/tc_extended_ditto/run.sh
+++ b/tests/tc_extended_ditto/run.sh
@@ -1,0 +1,5 @@
+set -e
+set -u
+
+../../bin/dcd-client $1 file.d -x -c80 > actual1.txt
+diff actual1.txt expected1.txt


### PR DESCRIPTION
adds a unittest for `/// ditto` in extended mode

Depends on dlang-community/dsymbol#111
- [x] merged & tagged
- [x] dub dependency updated

I should probably add a few scope unittests for ditto first