### PR TITLE
Fix file import test bleeding into other tests

### DIFF
--- a/tests/tc036/run.sh
+++ b/tests/tc036/run.sh
@@ -1,6 +1,9 @@
 set -e
 set -u
 
+../../bin/dcd-client $1 file.d -c 15 | sed s\""$(dirname "$(pwd)")"\"\" > actual3.txt
+diff actual3.txt expected3.txt
+
 ../../bin/dcd-client $1 -I bar.d
 
 ../../bin/dcd-client $1 file.d -c 15 | sed s\""$(dirname "$(pwd)")"\"\" > actual1.txt
@@ -8,3 +11,8 @@ diff actual1.txt expected1.txt
 
 ../../bin/dcd-client $1 file.d -c 40 | sed s\""$(dirname "$(pwd)")"\"\" > actual2.txt
 diff actual2.txt expected2.txt
+
+../../bin/dcd-client $1 -R bar.d
+
+../../bin/dcd-client $1 file.d -c 15 | sed s\""$(dirname "$(pwd)")"\"\" > actual3.txt
+diff actual3.txt expected3.txt

--- a/tests/tc_issue558/expected.txt
+++ b/tests/tc_issue558/expected.txt
@@ -1,3 +1,2 @@
 identifiers
-bar	M
 module1	M


### PR DESCRIPTION
tc036 added an import file but didn't remove it again. Another unittest just added it to the expected results list, though it should get removed after running the unittest

But there seems to be an issue with import files bleeding their scope into other stuff.