### PR TITLE
fix wrong completion for if variable initialized with an array

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -7,7 +7,7 @@
   ],
   "license": "GPL-3.0",
   "dependencies": {
-    "dsymbol": "~>0.5.6",
+    "dsymbol": "~>0.5.7",
     "libdparse": "~>0.10.10",
     "msgpack-d": "~>1.0.0-beta.7",
     "stdx-allocator": "~>2.77.5"

--- a/tests/tc_if_auto_array/expected.txt
+++ b/tests/tc_if_auto_array/expected.txt
@@ -1,0 +1,10 @@
+identifiers
+alignof	k
+dup	k
+idup	k
+init	k
+length	k
+mangleof	k
+ptr	k
+sizeof	k
+stringof	k

--- a/tests/tc_if_auto_array/file.d
+++ b/tests/tc_if_auto_array/file.d
@@ -1,0 +1,1 @@
+module m; void foo(){if(const s = "string"){s.}}

--- a/tests/tc_if_auto_array/run.sh
+++ b/tests/tc_if_auto_array/run.sh
@@ -1,0 +1,5 @@
+set -e
+set -u
+
+../../bin/dcd-client $1 file.d -c46 > actual.txt
+diff actual.txt expected.txt


### PR DESCRIPTION
I suspect that the bug in dsymbol affected other more realistic cases than the one that had allowed to detect the problem so finally i decided to propagate the fix in dcd without waiting the next big change.