### PR TITLE
Fix client exception handling

### DIFF
--- a/src/dcd/client/client.d
+++ b/src/dcd/client/client.d
@@ -36,6 +36,21 @@ import dcd.common.socket;
 
 int main(string[] args)
 {
+	try
+	{
+		return runClient(args);
+	}
+	catch (Exception e)
+	{
+		stderr.writeln(e);
+		return 1;
+	}
+}
+
+private:
+
+int runClient(string[] args)
+{
 	sharedLog.fatalHandler = () {};
 
 	size_t cursorPos = size_t.max;
@@ -242,8 +257,6 @@ int main(string[] args)
 
 	return 0;
 }
-
-private:
 
 void printHelp(string programName)
 {


### PR DESCRIPTION
On windows the exceptions caused by socket connections are not catched and therefore causes windows dialogs like this one
![image](https://user-images.githubusercontent.com/1451047/50729333-539ab780-1138-11e9-8ffd-fbaddbf2cca8.png)

This makes the usage of DCD within IntelliJ almost unusuable as it hangs (due to the dialogs which will only be shown after closing IntelliJ).

This pull request wraps the client main logic within a separate function and catches all exceptions.