### PR TITLE
dcd.common.messages: Fix spurious "Could not unpack the response" errors

### DIFF
--- a/src/dcd/common/messages.d
+++ b/src/dcd/common/messages.d
@@ -220,7 +220,7 @@ AutocompleteResponse getResponse(Socket socket)
 		if (bytesReceived == 0)
 			break;
 		unpacker.feed(buffer[0..bytesReceived]);
-	} while (bytesReceived == buffer.length);
+	} while (true);
 
 	if (unpacker.size == 0)
 		throw new Exception("Server closed the connection, 0 bytes received");


### PR DESCRIPTION
`recv` is allowed to return less than the indicated buffer size, even when more data may still become available. Exiting the read loop on such conditions caused fragmented responses to be partially read, then failing to decode. To read the entire response, we need to keep reading until the connection is properly closed (`recv` returns zero).