### PR TITLE
add RequestKind.requiresSourceCode, fix #617

### DIFF
--- a/common/src/dcd/common/messages.d
+++ b/common/src/dcd/common/messages.d
@@ -78,6 +78,10 @@ enum RequestKind : ushort
 	localUse =     	 0b00000010_00000000,
 	/// Remove import directory from server
 	removeImport =   0b00000100_00000000,
+
+	/// These request kinds require source code and won't be executed if there
+	/// is no source sent
+	requiresSourceCode = autocomplete | doc | symbolLocation | search | localUse,
 	// dfmt on
 }
 

--- a/tests/tc_empty_requests/run.sh
+++ b/tests/tc_empty_requests/run.sh
@@ -1,0 +1,7 @@
+set -e
+set -u
+
+../../bin/dcd-client $1 -s foo < /dev/null
+../../bin/dcd-client $1 -c 1 < /dev/null
+../../bin/dcd-client $1 -d -c 1 < /dev/null
+../../bin/dcd-client $1 -u -c 1 < /dev/null


### PR DESCRIPTION
this is a or-combined mask of the request kinds which operate on `request.sourceCode`. Before if a client sent a request without source code (with empty source) to one of these commands, the server would
crash with an assertion failure, now the server returns an empty response.