### PR TITLE
fix --localUse off-by-one error

### DIFF
--- a/src/dcd/server/autocomplete/localuse.d
+++ b/src/dcd/server/autocomplete/localuse.d
@@ -84,8 +84,8 @@ public AutocompleteResponse findLocalUse(AutocompleteRequest request,
 		{
 			if (t.type != tok!"identifier")
 				continue;
-			if (request.cursorPosition >= t.index &&
-				request.cursorPosition < t.index + t.text.length)
+			if (request.cursorPosition > t.index &&
+				request.cursorPosition <= t.index + t.text.length)
 			{
 				sourceToken = tokenArray.ptr + i;
 				break;

--- a/tests/tc033/run.sh
+++ b/tests/tc033/run.sh
@@ -3,3 +3,7 @@ set -u
 
 ../../bin/dcd-client $1 file.d -u -c22 | sed s\""$(dirname "$(pwd)")"\"\" > actual1.txt
 diff actual1.txt expected1.txt
+
+# should work on last character of identifier
+../../bin/dcd-client $1 file.d -u -c24 | sed s\""$(dirname "$(pwd)")"\"\" > actual2.txt
+diff actual2.txt expected1.txt


### PR DESCRIPTION
makes behavior consistent with find declaration - where the first character of a token does not yield results, but the last does

Before there was a weird edge case of it just finding the declaration on first character and no uses and finding nothing on the last character.