### PR TITLE
Get type's symbol recursively to handle cases with auto as variable

### DIFF
--- a/src/dcd/server/autocomplete/util.d
+++ b/src/dcd/server/autocomplete/util.d
@@ -772,7 +772,7 @@ AutocompleteResponse.Completion makeSymbolCompletionInfo(const DSymbol* symbol, 
 		// TODO: should probably make it fully recursive,
 		if(s.type && s.type.kind == CompletionKind.functionName) s = s.type;
 
-		definition = s.type.name ~ ' ' ~ s.name;
+		definition = s.type.name ~ ' ' ~ symbol.name;
 	}
 	else if (kind == CompletionKind.enumMember)
 		definition = symbol.name; // TODO: add enum value to definition string

--- a/src/dcd/server/autocomplete/util.d
+++ b/src/dcd/server/autocomplete/util.d
@@ -757,7 +757,23 @@ AutocompleteResponse.Completion makeSymbolCompletionInfo(const DSymbol* symbol, 
 {
 	string definition;
 	if ((kind == CompletionKind.variableName || kind == CompletionKind.memberVariableName) && symbol.type)
-		definition = symbol.type.name ~ ' ' ~ symbol.name;
+	{
+		DSymbol* s = cast(DSymbol*)symbol;
+
+		// if using auto as variable declaration, then the type will be the function name
+		// so let's get what the function symbol points to to get the actual type
+		//
+		// MyData myfunction() {}  
+		// auto data = myfunction();  <-- this gives 'myfunction' as type
+		//
+		// with this recurtion we now get the proper type: 'MyData'
+		//
+		// TODO: should probably move it at the call site
+		// TODO: should probably make it fully recursive,
+		if(s.type) s = s.type;
+
+		definition = s.type.name ~ ' ' ~ s.name;
+	}
 	else if (kind == CompletionKind.enumMember)
 		definition = symbol.name; // TODO: add enum value to definition string
 	else

--- a/src/dcd/server/autocomplete/util.d
+++ b/src/dcd/server/autocomplete/util.d
@@ -772,7 +772,7 @@ AutocompleteResponse.Completion makeSymbolCompletionInfo(const DSymbol* symbol, 
 		// TODO: should probably make it fully recursive,
 		if(s.type && s.type.kind == CompletionKind.functionName) s = s.type;
 
-		definition = s.type.name ~ ' ' ~ symbol.name;
+		definition = s.name ~ ' ' ~ symbol.name;
 	}
 	else if (kind == CompletionKind.enumMember)
 		definition = symbol.name; // TODO: add enum value to definition string

--- a/src/dcd/server/autocomplete/util.d
+++ b/src/dcd/server/autocomplete/util.d
@@ -758,8 +758,6 @@ AutocompleteResponse.Completion makeSymbolCompletionInfo(const DSymbol* symbol, 
 	string definition;
 	if ((kind == CompletionKind.variableName || kind == CompletionKind.memberVariableName) && symbol.type)
 	{
-		const(DSymbol)* s = symbol;
-
 		// if using auto as variable declaration, then the type will be the function name
 		// so let's get what the function symbol points to to get the actual type
 		//

--- a/src/dcd/server/autocomplete/util.d
+++ b/src/dcd/server/autocomplete/util.d
@@ -758,7 +758,7 @@ AutocompleteResponse.Completion makeSymbolCompletionInfo(const DSymbol* symbol, 
 	string definition;
 	if ((kind == CompletionKind.variableName || kind == CompletionKind.memberVariableName) && symbol.type)
 	{
-		DSymbol* s = cast(DSymbol*)symbol;
+		const(DSymbol)* s = symbol;
 
 		// if using auto as variable declaration, then the type will be the function name
 		// so let's get what the function symbol points to to get the actual type
@@ -770,7 +770,7 @@ AutocompleteResponse.Completion makeSymbolCompletionInfo(const DSymbol* symbol, 
 		//
 		// TODO: should probably move it at the call site
 		// TODO: should probably make it fully recursive,
-		if(s.type) s = s.type;
+		if(s.type && s.type.kind == CompletionKind.functionName) s = s.type;
 
 		definition = s.type.name ~ ' ' ~ s.name;
 	}

--- a/src/dcd/server/autocomplete/util.d
+++ b/src/dcd/server/autocomplete/util.d
@@ -770,9 +770,19 @@ AutocompleteResponse.Completion makeSymbolCompletionInfo(const DSymbol* symbol, 
 		//
 		// TODO: should probably move it at the call site
 		// TODO: should probably make it fully recursive,
-		if(s.type && s.type.kind == CompletionKind.functionName) s = s.type;
-
-		definition = s.name ~ ' ' ~ symbol.name;
+		if (symbol.type.kind == CompletionKind.functionName && symbol.type.type)
+		{
+			// if can resolve the function's type, that means it is a known type and not return auto
+			const(DSymbol)* resolved = symbol.type.type;
+			if (resolved.type)
+				definition = resolved.type.name ~ ' ' ~ symbol.name;
+			else
+				definition = resolved.name ~ ' ' ~ symbol.name;
+		}
+		else
+		{
+			definition = symbol.type.name ~ ' ' ~ symbol.name;
+		}
 	}
 	else if (kind == CompletionKind.enumMember)
 		definition = symbol.name; // TODO: add enum value to definition string

--- a/tests/tc_auto_variable/expected.txt
+++ b/tests/tc_auto_variable/expected.txt
@@ -1,0 +1,4 @@
+identifiers
+data	v	MyData want	stdin 56	
+dchar	k			
+double	k			

--- a/tests/tc_auto_variable/expected.txt
+++ b/tests/tc_auto_variable/expected.txt
@@ -1,4 +1,4 @@
 identifiers
-data	v	MyData want	stdin 56	
+data	v	MyData data	stdin 56	
 dchar	k			
 double	k			

--- a/tests/tc_auto_variable/expected_crash_return_auto.txt
+++ b/tests/tc_auto_variable/expected_crash_return_auto.txt
@@ -1,0 +1,4 @@
+identifiers
+data	v	weird data	stdin 55	
+dchar	k			
+double	k			

--- a/tests/tc_auto_variable/expected_nf.txt
+++ b/tests/tc_auto_variable/expected_nf.txt
@@ -1,0 +1,4 @@
+identifiers
+data	v	MyData data	stdin 41	
+dchar	k			
+double	k			

--- a/tests/tc_auto_variable/file.d
+++ b/tests/tc_auto_variable/file.d
@@ -1,0 +1,1 @@
+struct MyData{} MyData want() { return MyData(); } auto data = want(); d

--- a/tests/tc_auto_variable/file_crash_return_auto.d
+++ b/tests/tc_auto_variable/file_crash_return_auto.d
@@ -1,0 +1,1 @@
+struct MyData{} auto weird(){ return MyData(); }; auto data = weird(); d

--- a/tests/tc_auto_variable/file_nf.d
+++ b/tests/tc_auto_variable/file_nf.d
@@ -1,0 +1,1 @@
+struct MyData{} alias MyData Stuff; auto data = Stuff(); d

--- a/tests/tc_auto_variable/run.sh
+++ b/tests/tc_auto_variable/run.sh
@@ -6,3 +6,6 @@ diff actual.txt expected.txt
 
 ../../bin/dcd-client $1 --extended file_nf.d -c58 > actual_nf.txt
 diff actual_nf.txt expected_nf.txt
+
+../../bin/dcd-client $1 --extended file_crash_return_auto.d -c72 > actual_crash_return_auto.txt
+diff actual_crash_return_auto.txt expected_crash_return_auto.txt

--- a/tests/tc_auto_variable/run.sh
+++ b/tests/tc_auto_variable/run.sh
@@ -3,3 +3,6 @@ set -u
 
 ../../bin/dcd-client $1 --extended file.d -c72 > actual.txt
 diff actual.txt expected.txt
+
+../../bin/dcd-client $1 --extended file_nf.d -c58 > actual_nf.txt
+diff actual_nf.txt expected_nf.txt

--- a/tests/tc_auto_variable/run.sh
+++ b/tests/tc_auto_variable/run.sh
@@ -1,0 +1,5 @@
+set -e
+set -u
+
+../../bin/dcd-client $1 --extended file.d -c72 > actual.txt
+diff actual.txt expected.txt


### PR DESCRIPTION
Let's see this easy reproducible code:

```D

struct MyData
{

}

MyData what_i_want()
{}

void main() {

   auto data= what_i_want();
   da|
}
```

![image](https://user-images.githubusercontent.com/18348637/131504861-d7a767cc-e78f-4004-93be-28b41fbbdb46.png)
![image](https://user-images.githubusercontent.com/18348637/131504926-0df964cc-2aca-4831-b477-6c1dc2733eab.png)



at this cursor position, DCD will say the type of ``data`` is the function name ``what_i_want`` and that's wrong!

the problem here is it is because variable declaration is ``auto``, so DCD tells us that we need to check the type of that function

to do that we simply just recursively ge the symbol from the actual function symbol to return the proper one with the right type


now it works as expected:

![image](https://user-images.githubusercontent.com/18348637/131504674-3b4ae295-7dc3-4ad0-b534-94d67427cad0.png)

even when we mix multiple autos 

![image](https://user-images.githubusercontent.com/18348637/131505040-634e7ae7-ab9c-40c3-9aa9-e622d642f925.png)


We probably want to make this properly fully recursive, but for now it works, and i didn't want to introduce more changes, it's gonna be part of something bigger to handle ``auto + cast`` cases that i plan to work on later, but that's a story for another PR