### PR TITLE
UFCS support

### DIFF
--- a/src/dcd/server/autocomplete/complete.d
+++ b/src/dcd/server/autocomplete/complete.d
@@ -502,7 +502,7 @@ void setCompletions(T)(ref AutocompleteResponse response,
 	Scope* completionScope, T tokens, size_t cursorPosition,
 	CompletionType completionType, bool isBracket = false, string partial = null)
 {
-	static void addSymToResponse(const(DSymbol)* s, ref AutocompleteResponse r, string p,
+	static void addSymbolsToResponse(const(DSymbol)* s, ref AutocompleteResponse r, string p,
 		Scope* completionScope, size_t[] circularGuard = [])
 	{
 		if (circularGuard.canFind(cast(size_t) s))
@@ -518,7 +518,7 @@ void setCompletions(T)(ref AutocompleteResponse response,
 				r.completions ~= makeSymbolCompletionInfo(sym, sym.kind);
 			}
 			if (sym.kind == CompletionKind.importSymbol && !sym.skipOver && sym.type !is null)
-				addSymToResponse(sym.type, r, p, completionScope, circularGuard ~ (cast(size_t) s));
+				addSymbolsToResponse(sym.type, r, p, completionScope, circularGuard ~ (cast(size_t) s));
 		}
 	}
 
@@ -577,8 +577,12 @@ void setCompletions(T)(ref AutocompleteResponse response,
 			if (symbols.length == 0)
 				return;
 		}
-		addSymToResponse(symbols[0], response, partial, completionScope);
+		addSymbolsToResponse(symbols[0], response, partial, completionScope);
 		response.completionType = CompletionType.identifiers;
+
+		// UFCS completion
+		foreach (const symbol; getSymbolsForUFCS(completionScope, symbols[0], cursorPosition))
+			addSymbolsToResponse(symbol, response, partial, completionScope);
 	}
 	else if (completionType == CompletionType.calltips)
 	{


### PR DESCRIPTION
Merge of https://github.com/SSoulaimane/dcd/commit/dc66681 to master. Works locally for me.

Would like to add prel support for picking correct overload when multiple arguments are used. But this isn't supported for normal functions calls either so for later.

This works partially for me. Some UCFS-calls work some don't. No crashes. But the big structure is in place. There seems to be some bugs in picking the correct token for lookup based on the current buffer position. Shouldn't be that difficult to fix. Also would be nice to starting picking the correct overloads for normal function calls aswell as UFCS-calls. Initially just by looking at the number of compile-time and run-time arguments passed and match with parameters of definitions.

Closes https://github.com/dlang-community/DCD/issues/13.