### PR TITLE
Use more adaptive time formatting because many requests finish in 0 milliseconds

### DIFF
--- a/src/dcd/server/main.d
+++ b/src/dcd/server/main.d
@@ -185,7 +185,7 @@ int runServer(string[] args)
 
 	sw.stop();
 	info(cache.symbolsAllocated, " symbols cached.");
-	info("Startup completed in ", sw.peek().total!"msecs"(), " milliseconds.");
+	info("Startup completed in ", sw.peek);
 
 	// No relative paths
 	version (Posix) chdir("/");
@@ -310,7 +310,7 @@ int runServer(string[] args)
 		}
 
 		sw.stop();
-		info("Request processed in ", sw.peek().total!"msecs"(), " milliseconds");
+		info("Request processed in ", sw.peek);
 	}
 	return 0;
 }


### PR DESCRIPTION
For the sake of better performance diagnostics.

Uses Phobos's elegant time printing. At startup this prints, for instance,

```
2021-10-10T12:42:28.372 [info] main.d:188:runServer Startup completed in 177 μs and 3 hnsecs
```

instead of

```
2021-10-10T12:42:28.372 [info] main.d:188:runServer Startup completed in 0 milliseconds
```
.