### PR TITLE
Symbols that call a function aren't relevant for the completion list

### DIFF
--- a/src/dcd/server/autocomplete/complete.d
+++ b/src/dcd/server/autocomplete/complete.d
@@ -664,7 +664,18 @@ bool mightBeRelevantInCompletionScope(const DSymbol* symbol, Scope* scope_)
 		// scope is the scope of the current file so if the symbol is not in there, it's not accessible
 		return false;
 	}
-
+	if (symbol.kind == CompletionKind.functionName && !symbol.type)
+	{
+		// if it's a function and is isn't represented by a type
+		// that mean it is a symbol that calls the function
+		// so we can just ignore it
+		// eg:
+		//     void test(){}
+		//     
+		//     te <--- cursor here, the symbol will be the line bellow, it's useless, just show the actual function
+		//     test();
+		return false;
+	}
 	return true;
 }
 


### PR DESCRIPTION
They are not needed

Otherwise they show up in the completion list

**Before** (there are 2 completion item, one for the useless, and the other for the actual function):
![Code_Di8Jgm3u0i](https://user-images.githubusercontent.com/94763084/142932436-6182cd64-b687-466d-aca1-605b3f858246.png)

**After**:
![image](https://user-images.githubusercontent.com/94763084/142932411-85e675ed-cb86-4e39-8a6f-09712ca3ca23.png)


