### PR TITLE
Also generate ctor calltips for symbols with a callTip

### DIFF
--- a/src/dcd/server/autocomplete/complete.d
+++ b/src/dcd/server/autocomplete/complete.d
@@ -619,10 +619,16 @@ void setCompletions(T)(ref AutocompleteResponse response,
 					}
 				}
 			}
+		}
+		if (symbols[0].kind != CompletionKind.functionName
+			&& (symbols[0].callTip is null))
+		{
 			if (symbols[0].kind == CompletionKind.structName
 				|| symbols[0].kind == CompletionKind.className)
 			{
+
 				auto constructor = symbols[0].getPartsByName(CONSTRUCTOR_SYMBOL_NAME);
+
 				if (constructor.length == 0)
 				{
 					// Build a call tip out of the struct fields
@@ -640,6 +646,7 @@ void setCompletions(T)(ref AutocompleteResponse response,
 				}
 			}
 		}
+
 	setCallTips:
 		response.completionType = CompletionType.calltips;
 		foreach (symbol; symbols)


### PR DESCRIPTION
This is needed because in an upcoming PR i have moved

This: https://github.com/Pure-D/serve-d/blob/aeae249f9fdc6269c7f4963907eb5ed645d0691c/source/served/commands/complete.d#L969

Into: https://github.com/dlang-community/DCD/blob/2bfd3d004ff7eda2428353d2ab44f389dfd5b8e0/src/dcd/server/autocomplete/util.d#L756

Since it'll set the callTip for struct/class, this logic must be updated to take that into account