### PR TITLE
Also generate ctor calltips for Struct/Class symbols with a callTip

### DIFF
--- a/src/dcd/server/autocomplete/complete.d
+++ b/src/dcd/server/autocomplete/complete.d
@@ -614,27 +614,31 @@ void setCompletions(T)(ref AutocompleteResponse response,
 					}
 				}
 			}
-			if (symbols[0].kind == CompletionKind.structName
-				|| symbols[0].kind == CompletionKind.className)
+		}
+
+		if (symbols[0].kind == CompletionKind.structName
+			|| symbols[0].kind == CompletionKind.className)
+		{
+
+			auto constructor = symbols[0].getPartsByName(CONSTRUCTOR_SYMBOL_NAME);
+
+			if (constructor.length == 0)
 			{
-				auto constructor = symbols[0].getPartsByName(CONSTRUCTOR_SYMBOL_NAME);
-				if (constructor.length == 0)
+				// Build a call tip out of the struct fields
+				if (symbols[0].kind == CompletionKind.structName)
 				{
-					// Build a call tip out of the struct fields
-					if (symbols[0].kind == CompletionKind.structName)
-					{
-						response.completionType = CompletionType.calltips;
-						response.completions = [generateStructConstructorCalltip(symbols[0])];
-						return;
-					}
-				}
-				else
-				{
-					symbols = constructor;
-					goto setCallTips;
+					response.completionType = CompletionType.calltips;
+					response.completions = [generateStructConstructorCalltip(symbols[0])];
+					return;
 				}
 			}
+			else
+			{
+				symbols = constructor;
+				goto setCallTips;
+			}
 		}
+
 	setCallTips:
 		response.completionType = CompletionType.calltips;
 		foreach (symbol; symbols)


### PR DESCRIPTION
This is needed because of this PR: https://github.com/dlang-community/dsymbol/pull/175

Since it'll set the callTip for struct/class, this logic must be updated to take that into account
