### PR TITLE
DSymbol: RUSShyTwo: Properly construct a callTip for pointers and symbols with breadcrumbs (T, [], *, etc)

### DIFF
--- a/dsymbol/src/dsymbol/conversion/first.d
+++ b/dsymbol/src/dsymbol/conversion/first.d
@@ -1097,6 +1097,7 @@ private:
 		DSymbol* acSymbol = GCAllocator.instance.make!DSymbol(istring(name), kind);
 		acSymbol.location = location;
 		acSymbol.symbolFile = symbolFile;
+		acSymbol.callTip = istring(name);
 		symbolsAllocated++;
 		return GCAllocator.instance.make!SemanticSymbol(acSymbol);
 	}
@@ -1126,9 +1127,7 @@ private:
 
 		foreach (suffix; type.typeSuffixes)
 		{
-			if (suffix.star != tok!"")
-				continue;
-			else if (suffix.type)
+			if (suffix.type)
 				lookup.breadcrumbs.insert(ASSOC_ARRAY_SYMBOL_NAME);
 			else if (suffix.array)
 				lookup.breadcrumbs.insert(ARRAY_SYMBOL_NAME);

--- a/dsymbol/src/dsymbol/symbol.d
+++ b/dsymbol/src/dsymbol/symbol.d
@@ -339,7 +339,7 @@ struct DSymbol
 	 */
 	alias PartsAllocator = GCAllocator; // NOTE using `Mallocator` here fails when analysing Phobos
 	alias Parts = TTree!(SymbolOwnership, PartsAllocator, true, "a < b");
-	private Parts parts;
+	package Parts parts;
 
 	/**
 	 * DSymbol's name


### PR DESCRIPTION
rebased, squashed and moved from https://github.com/dlang-community/dsymbol/pull/175

PR by @RUSShyTwo 