### PR TITLE
OSX fixes

### DIFF
--- a/common/src/dcd/common/messages.d
+++ b/common/src/dcd/common/messages.d
@@ -205,7 +205,15 @@ bool sendRequest(Socket socket, AutocompleteRequest request)
 	auto messageLength = message.length;
 	messageBuffer[0 .. size_t.sizeof] = (cast(ubyte*) &messageLength)[0 .. size_t.sizeof];
 	messageBuffer[size_t.sizeof .. $] = message[];
-	return socket.send(messageBuffer) == messageBuffer.length;
+	size_t i;
+	while (i < messageBuffer.length)
+	{
+		auto sent = socket.send(messageBuffer[i .. $]);
+		if (sent == Socket.ERROR)
+			return false;
+		i += sent;
+	}
+	return true;
 }
 
 /**

--- a/src/dcd/client/client.d
+++ b/src/dcd/client/client.d
@@ -151,7 +151,9 @@ int runClient(string[] args)
 			request.kind = RequestKind.clearCache;
 		Socket socket = createSocket(socketFile, port);
 		scope (exit) { socket.shutdown(SocketShutdown.BOTH); socket.close(); }
-		return sendRequest(socket, request) ? 0 : 1;
+		if (!sendRequest(socket, request))
+			return 1;
+		return getResponse(socket).completionType == "ack" ? 0 : 2;
 	}
 	else if (addedImportPaths.length > 0 || removedImportPaths.length > 0)
 	{
@@ -165,7 +167,7 @@ int runClient(string[] args)
 			scope (exit) { socket.shutdown(SocketShutdown.BOTH); socket.close(); }
 			if (!sendRequest(socket, request))
 				return 1;
-			return 0;
+			return getResponse(socket).completionType == "ack" ? 0 : 2;
 		}
 	}
 	else if (listImports)
@@ -173,7 +175,8 @@ int runClient(string[] args)
 		request.kind |= RequestKind.listImports;
 		Socket socket = createSocket(socketFile, port);
 		scope (exit) { socket.shutdown(SocketShutdown.BOTH); socket.close(); }
-		sendRequest(socket, request);
+		if (!sendRequest(socket, request))
+			return 1;
 		AutocompleteResponse response = getResponse(socket);
 		printImportList(response);
 		return 0;


### PR DESCRIPTION
On OSX ARM accepting sockets would fail because the sender side (dcd-client) was generating, sending the whole packet and closing the socket faster than phobos was with accepting the socket, causing an exception in setOption inside socket.accept, which is now commented in the code as well.