### PR TITLE
use `isCallableWithArg` in paren completion

### DIFF
--- a/tests/tc_ufcs_calltip_in_func/file.d
+++ b/tests/tc_ufcs_calltip_in_func/file.d
@@ -1,5 +1,9 @@
 void showSomething(int x, string message, bool ok){}
 void showSomething(int x, string message, bool ok, float percentage){}
+void showSomething(string x, string message, bool ok){}
+void showSomething(){}
+int showSomething;
+struct showSomething { int x; }
 
 void main(){
 	int x;

--- a/tests/tc_ufcs_calltip_in_func/run.sh
+++ b/tests/tc_ufcs_calltip_in_func/run.sh
@@ -1,5 +1,5 @@
 set -e
 set -u
 
-../../bin/dcd-client $1 -c163 file.d > actual.txt
+../../bin/dcd-client $1 -c293 file.d > actual.txt
 diff actual.txt expected.txt


### PR DESCRIPTION
For consistency and to allow future changes to type matching (e.g. implicit type conversion)