### PR TITLE
fixed shared logger usage

### DIFF
--- a/src/dcd/client/client.d
+++ b/src/dcd/client/client.d
@@ -51,7 +51,7 @@ private:
 
 int runClient(string[] args)
 {
-	sharedLog.fatalHandler = () {};
+	(cast()sharedLog).fatalHandler = () {};
 
 	size_t cursorPos = size_t.max;
 	string[] addedImportPaths;

--- a/src/dcd/server/main.d
+++ b/src/dcd/server/main.d
@@ -75,7 +75,7 @@ int runServer(string[] args)
 		string socketFile = generateSocketName();
 	}
 
-	sharedLog.fatalHandler = () {};
+	(cast()sharedLog).fatalHandler = () {};
 
 	try
 	{


### PR DESCRIPTION
should fix DMD 2.101+ compatibility, where std.experimental.logger was moved into std.logger

I don't think there is any other way to do it right now than to cast away the shared.