### PR TITLE
Improve non-linux testing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/tests/*/*.d           text eol=lf

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -23,7 +23,7 @@ function startServer()
 {
 	"$server" "$tcp" --ignoreConfig -I $IMPORTS 2>stderr.txt > stdout.txt &
 	server_pid=$!
-	sleep 1s;
+	sleep 1
 }
 
 # Make sure that the server is shut down
@@ -33,7 +33,7 @@ echo "Shutting down currently-running server..."
 
 for socket in unix tcp; do
 	# allow some time for server to shutdown
-	sleep 0.5s;
+	sleep 0.5;
 
 	if [[ $socket == "tcp" ]]; then
 		tcp="--tcp"
@@ -54,7 +54,7 @@ for socket in unix tcp; do
 		fi
 		sleepTime=$((1 << $i))
 		echo "Server isn't up yet. Sleeping for ${sleepTime}s"
-		sleep "${sleepTime}s"
+		sleep "${sleepTime}"
 	done
 
 	# Run tests

--- a/tests/tc001/run.sh
+++ b/tests/tc001/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c12 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc002/run.sh
+++ b/tests/tc002/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c52 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc003/run.sh
+++ b/tests/tc003/run.sh
@@ -2,7 +2,7 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c696 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c713 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc004/run.sh
+++ b/tests/tc004/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c13 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc005/run.sh
+++ b/tests/tc005/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c136 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc006/run.sh
+++ b/tests/tc006/run.sh
@@ -2,13 +2,13 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c184 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c199 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c216 > actual3.txt
-diff actual3.txt expected3.txt
+diff actual3.txt expected3.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c231 > actual4.txt
-diff actual4.txt expected4.txt
+diff actual4.txt expected4.txt --strip-trailing-cr

--- a/tests/tc007/run.sh
+++ b/tests/tc007/run.sh
@@ -2,7 +2,7 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c97 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c130 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc008/run.sh
+++ b/tests/tc008/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c113 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc009/run.sh
+++ b/tests/tc009/run.sh
@@ -2,10 +2,10 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c83 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c93 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c148 > actual3.txt
-diff actual3.txt expected3.txt
+diff actual3.txt expected3.txt --strip-trailing-cr

--- a/tests/tc010/run.sh
+++ b/tests/tc010/run.sh
@@ -7,11 +7,11 @@ cp testfile1_old.d ../imports/testfile1.d
 sleep 1
 
 ../../bin/dcd-client $1 file.d -c84 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 cp testfile1_new.d ../imports/testfile1.d
 # Same here
 sleep 1
 
 ../../bin/dcd-client $1 file.d -c84 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc010/run.sh
+++ b/tests/tc010/run.sh
@@ -4,14 +4,14 @@ set -u
 cp testfile1_old.d ../imports/testfile1.d
 # Sleep because modification times aren't stored with granularity of less
 # than one second
-sleep 1s;
+sleep 1
 
 ../../bin/dcd-client $1 file.d -c84 > actual1.txt
 diff actual1.txt expected1.txt
 
 cp testfile1_new.d ../imports/testfile1.d
 # Same here
-sleep 1s;
+sleep 1
 
 ../../bin/dcd-client $1 file.d -c84 > actual2.txt
 diff actual2.txt expected2.txt

--- a/tests/tc011/run.sh
+++ b/tests/tc011/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c48 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc012/run.sh
+++ b/tests/tc012/run.sh
@@ -2,7 +2,7 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c35 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c61 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc013/run.sh
+++ b/tests/tc013/run.sh
@@ -2,7 +2,7 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c187 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c211 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc014/run.sh
+++ b/tests/tc014/run.sh
@@ -4,14 +4,14 @@ set -u
 cp testfile2_old.d ../imports/testfile2.d
 # Sleep because modification times aren't stored with granularity of less
 # than one second
-sleep 1s;
+sleep 1
 
 ../../bin/dcd-client $1 file.d -c39 > actual1.txt
 diff actual1.txt expected1.txt
 
 cp testfile2_new.d ../imports/testfile2.d
 # Same here
-sleep 1s;
+sleep 1
 
 ../../bin/dcd-client $1 file.d -c39 > actual2.txt
 diff actual2.txt expected2.txt

--- a/tests/tc014/run.sh
+++ b/tests/tc014/run.sh
@@ -7,11 +7,11 @@ cp testfile2_old.d ../imports/testfile2.d
 sleep 1
 
 ../../bin/dcd-client $1 file.d -c39 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 cp testfile2_new.d ../imports/testfile2.d
 # Same here
 sleep 1
 
 ../../bin/dcd-client $1 file.d -c39 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc015/run.sh
+++ b/tests/tc015/run.sh
@@ -2,7 +2,7 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file1.d -c84 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file2.d -c73 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc016/run.sh
+++ b/tests/tc016/run.sh
@@ -2,7 +2,7 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c24 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c57 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc017/run.sh
+++ b/tests/tc017/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c33 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc018/run.sh
+++ b/tests/tc018/run.sh
@@ -2,7 +2,7 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c61 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c88 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc019/run.sh
+++ b/tests/tc019/run.sh
@@ -2,7 +2,7 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c84 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c111 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc020/run.sh
+++ b/tests/tc020/run.sh
@@ -2,7 +2,7 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c159 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c199 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc021/run.sh
+++ b/tests/tc021/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c1 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc022/run.sh
+++ b/tests/tc022/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c16 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc023/run.sh
+++ b/tests/tc023/run.sh
@@ -2,7 +2,7 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c117 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c89 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc024/run.sh
+++ b/tests/tc024/run.sh
@@ -2,25 +2,25 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c286 -d > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c290 -d > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c294 -d > actual3.txt
-diff actual3.txt expected3.txt
+diff actual3.txt expected3.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c298 -d> actual4.txt
-diff actual4.txt expected4.txt
+diff actual4.txt expected4.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c302 -d> actual5.txt
-diff actual5.txt expected5.txt
+diff actual5.txt expected5.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c306 -d> actual6.txt
-diff actual6.txt expected6.txt
+diff actual6.txt expected6.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c313 -d> actual7.txt
-diff actual7.txt expected7.txt
+diff actual7.txt expected7.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c432 -d> actual8.txt
-diff actual8.txt expected8.txt
+diff actual8.txt expected8.txt --strip-trailing-cr

--- a/tests/tc025/run.sh
+++ b/tests/tc025/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c94 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc026/run.sh
+++ b/tests/tc026/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c53 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc027/run.sh
+++ b/tests/tc027/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c66 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc028/run.sh
+++ b/tests/tc028/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c122 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc029/run.sh
+++ b/tests/tc029/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c73 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc030/run.sh
+++ b/tests/tc030/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c11 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc031/run.sh
+++ b/tests/tc031/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -d -c1 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc032/run.sh
+++ b/tests/tc032/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -l -c 15 | sed s\""$(dirname "$(pwd)")"\"\" > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc033/run.sh
+++ b/tests/tc033/run.sh
@@ -2,8 +2,8 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -u -c22 | sed s\""$(dirname "$(pwd)")"\"\" > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 # should work on last character of identifier
 ../../bin/dcd-client $1 file.d -u -c24 | sed s\""$(dirname "$(pwd)")"\"\" > actual2.txt
-diff actual2.txt expected1.txt
+diff actual2.txt expected1.txt --strip-trailing-cr

--- a/tests/tc034/run.sh
+++ b/tests/tc034/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -u -c1 | sed s\""$(dirname "$(pwd)")"\"\" > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc035/run.sh
+++ b/tests/tc035/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -u -c8 | sed s\""$(dirname "$(pwd)")"\"\" > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc036/run.sh
+++ b/tests/tc036/run.sh
@@ -2,17 +2,17 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c 15 | sed s\""$(dirname "$(pwd)")"\"\" > actual3.txt
-diff actual3.txt expected3.txt
+diff actual3.txt expected3.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 -I bar.d
 
 ../../bin/dcd-client $1 file.d -c 15 | sed s\""$(dirname "$(pwd)")"\"\" > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c 40 | sed s\""$(dirname "$(pwd)")"\"\" > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 -R bar.d
 
 ../../bin/dcd-client $1 file.d -c 15 | sed s\""$(dirname "$(pwd)")"\"\" > actual3.txt
-diff actual3.txt expected3.txt
+diff actual3.txt expected3.txt --strip-trailing-cr

--- a/tests/tc038/run.sh
+++ b/tests/tc038/run.sh
@@ -2,10 +2,10 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 implicit_array.d -c108 > actual.txt
-diff actual.txt expected1.txt
+diff actual.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 excplicit_array.d -c98 > actual.txt
-diff actual.txt expected1.txt
+diff actual.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 implicit_var.d -c108 > actual.txt
-diff actual.txt expected1.txt
+diff actual.txt expected1.txt --strip-trailing-cr

--- a/tests/tc039/run.sh
+++ b/tests/tc039/run.sh
@@ -2,5 +2,5 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c48 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr
 

--- a/tests/tc041/run.sh
+++ b/tests/tc041/run.sh
@@ -2,14 +2,14 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -d -c149 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -d -c158 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -d -c166 > actual3.txt
-diff actual3.txt expected3.txt
+diff actual3.txt expected3.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -d -c175 > actual4.txt
-diff actual4.txt expected4.txt
+diff actual4.txt expected4.txt --strip-trailing-cr
 

--- a/tests/tc042/run.sh
+++ b/tests/tc042/run.sh
@@ -2,7 +2,7 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -d -c18 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -d -c107 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc043/run.sh
+++ b/tests/tc043/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -l -c48 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc044/run.sh
+++ b/tests/tc044/run.sh
@@ -2,7 +2,7 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c12 -d > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c35 -d > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc045/run.sh
+++ b/tests/tc045/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c26 > actual.txt # segfault if -c29 ("  XX|"), bug!
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc046/run.sh
+++ b/tests/tc046/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -d -c11 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc047/run.sh
+++ b/tests/tc047/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -d -c124 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc048/run.sh
+++ b/tests/tc048/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c72 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc049/run.sh
+++ b/tests/tc049/run.sh
@@ -2,10 +2,10 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -l -c76 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -l -c47 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -l -c200 > actual3.txt
-diff actual3.txt expected3.txt
+diff actual3.txt expected3.txt --strip-trailing-cr

--- a/tests/tc050/run.sh
+++ b/tests/tc050/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c58 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc051/run.sh
+++ b/tests/tc051/run.sh
@@ -2,10 +2,10 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c29 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file1.d -c25 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file2.d -c74 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc053/run.sh
+++ b/tests/tc053/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c19 -d > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc054/run.sh
+++ b/tests/tc054/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c26 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc055/run.sh
+++ b/tests/tc055/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c35 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc056/run.sh
+++ b/tests/tc056/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c18 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc057/run.sh
+++ b/tests/tc057/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c47 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc058/run.sh
+++ b/tests/tc058/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c161 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc059/run.sh
+++ b/tests/tc059/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d --extended -c32 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc061/run.sh
+++ b/tests/tc061/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d --extended -c44 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc062/run.sh
+++ b/tests/tc062/run.sh
@@ -4,4 +4,4 @@ set -u
 ../../bin/dcd-client $1 -I $(pwd)
 echo | ../../bin/dcd-client $1 --search funcName > actual1.txt
 echo -e "$(pwd)/file.d\tf\t5" > expected1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc620/run.sh
+++ b/tests/tc620/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c25 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc_access_modifiers/run.sh
+++ b/tests/tc_access_modifiers/run.sh
@@ -4,23 +4,23 @@ set -u
 rm -f actual1.txt actual2.txt actual3.txt actual0.txt
 
 ../../bin/dcd-client $1 file1.d -c 137 | sed s\""$(dirname "$(pwd)")"\"\" > actual0.txt
-diff actual0.txt expected0.txt
+diff actual0.txt expected0.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 -I bar.d
 
 ../../bin/dcd-client $1 file1.d -c 137 | sed s\""$(dirname "$(pwd)")"\"\" > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file1.d -c 152 | sed s\""$(dirname "$(pwd)")"\"\" > actual1_1.txt
-diff actual1_1.txt expected1_1.txt
+diff actual1_1.txt expected1_1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file1.d -c 170 | sed s\""$(dirname "$(pwd)")"\"\" > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file2.d -c 83 | sed s\""$(dirname "$(pwd)")"\"\" > actual3.txt
-diff actual3.txt expected3.txt
+diff actual3.txt expected3.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 -R bar.d
 
 ../../bin/dcd-client $1 file1.d -c 137 | sed s\""$(dirname "$(pwd)")"\"\" > actual0.txt
-diff actual0.txt expected0.txt
+diff actual0.txt expected0.txt --strip-trailing-cr

--- a/tests/tc_accesschain_type/run.sh
+++ b/tests/tc_accesschain_type/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c103 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc_anon_class/run.sh
+++ b/tests/tc_anon_class/run.sh
@@ -2,6 +2,6 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file1.d -c77 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 ../../bin/dcd-client $1 file2.d -c55 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc_anon_struct/run.sh
+++ b/tests/tc_anon_struct/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c70 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc_bang_op_or_template/run.sh
+++ b/tests/tc_bang_op_or_template/run.sh
@@ -2,6 +2,6 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c49 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 ../../bin/dcd-client $1 file.d -c103 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc_base_template_type/run.sh
+++ b/tests/tc_base_template_type/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c22 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc_body_var/run.sh
+++ b/tests/tc_body_var/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c16 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc_calltip_in_func/run.sh
+++ b/tests/tc_calltip_in_func/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 -c66 <<< "class Bar{void fun(A param){}}class Foo{void foo(Bar bar){bar.fun(}}" > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc_char_dot/run.sh
+++ b/tests/tc_char_dot/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c14 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc_complete_kw/run.sh
+++ b/tests/tc_complete_kw/run.sh
@@ -2,10 +2,10 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file1.d -c25 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file2.d -c42 > actual2.txt
-diff actual2.txt expected1.txt
+diff actual2.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file3.d -c64 > actual3.txt
-diff actual3.txt expected3.txt
+diff actual3.txt expected3.txt --strip-trailing-cr

--- a/tests/tc_currmod_fqn/run.sh
+++ b/tests/tc_currmod_fqn/run.sh
@@ -2,8 +2,8 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file1.d -c82 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 ../../bin/dcd-client $1 file2.d -c46 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr
 ../../bin/dcd-client $1 file3.d -c11 > actual3.txt
-diff actual3.txt expected3.txt
+diff actual3.txt expected3.txt --strip-trailing-cr

--- a/tests/tc_ditto_scopes/run.sh
+++ b/tests/tc_ditto_scopes/run.sh
@@ -2,38 +2,38 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -d -c5 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -d -c61 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -d -c140 > actual3.txt
-diff actual3.txt expected3.txt
+diff actual3.txt expected3.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -d -c160 > actual4.txt
-diff actual4.txt expected4.txt
+diff actual4.txt expected4.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -d -c201 > actual5.txt
-diff actual5.txt expected5.txt
+diff actual5.txt expected5.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -d -c208 > actual6.txt
-diff actual6.txt expected6.txt
+diff actual6.txt expected6.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -d -c254 > actual7.txt
-diff actual7.txt expected7.txt
+diff actual7.txt expected7.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -d -c323 > actual8.txt
-diff actual8.txt expected8.txt
+diff actual8.txt expected8.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -d -c335 > actual8.1.txt
-diff actual8.1.txt expected8.1.txt
+diff actual8.1.txt expected8.1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -d -c414 > actual8.2.txt
-diff actual8.2.txt expected8.2.txt
+diff actual8.2.txt expected8.2.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -d -c425 > actual8.3.txt
-diff actual8.3.txt expected8.3.txt
+diff actual8.3.txt expected8.3.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -d -c457 > actual9.txt
-diff actual9.txt expected9.txt
+diff actual9.txt expected9.txt --strip-trailing-cr
 

--- a/tests/tc_empty_module/run.sh
+++ b/tests/tc_empty_module/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d --extended -c$(stat -c %s file.d) > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc_empty_module/run.sh
+++ b/tests/tc_empty_module/run.sh
@@ -1,5 +1,5 @@
 set -e
 set -u
 
-../../bin/dcd-client $1 file.d --extended -c$(stat -c %s file.d) > actual.txt
+../../bin/dcd-client $1 file.d --extended -c$(wc -c < file.d) > actual.txt
 diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc_erroneous_body_content/run.sh
+++ b/tests/tc_erroneous_body_content/run.sh
@@ -2,6 +2,6 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c 118 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 ../../bin/dcd-client $1 file.d -c 134 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc_extended_ditto/run.sh
+++ b/tests/tc_extended_ditto/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -x -c80 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc_if_auto_array/run.sh
+++ b/tests/tc_if_auto_array/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c46 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc_if_var/run.sh
+++ b/tests/tc_if_var/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c37 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc_import_symbol_list/run.sh
+++ b/tests/tc_import_symbol_list/run.sh
@@ -1,6 +1,6 @@
 set -e
 set -u
 
-../../bin/dcd-client $1 file.d --extended -I"$PWD"/newpackage -c$(stat -c %s file.d) > actual1.txt
+../../bin/dcd-client $1 file.d --extended -I"$PWD"/newpackage -c$(wc -c < file.d) > actual1.txt
 echo -e "identifiers\nSomeStruct\ts\t\t$PWD/newpackage/newmodule.d 26\t" > expected1.txt
 diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc_import_symbol_list/run.sh
+++ b/tests/tc_import_symbol_list/run.sh
@@ -3,4 +3,4 @@ set -u
 
 ../../bin/dcd-client $1 file.d --extended -I"$PWD"/newpackage -c$(stat -c %s file.d) > actual1.txt
 echo -e "identifiers\nSomeStruct\ts\t\t$PWD/newpackage/newmodule.d 26\t" > expected1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc_incomplete_switch/run.sh
+++ b/tests/tc_incomplete_switch/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c58 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc_issue558/run.sh
+++ b/tests/tc_issue558/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c37 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc_locate_ufcs_function/run.sh
+++ b/tests/tc_locate_ufcs_function/run.sh
@@ -3,4 +3,4 @@ set -u
 
 ../../bin/dcd-client $1 -c57 -l -I"$PWD"/barutils file.d > actual.txt
 echo -e "$PWD/barutils/barutils.d\t22" > expected.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc_middle_of_utf/run.sh
+++ b/tests/tc_middle_of_utf/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c1 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc_module_scope_op/run.sh
+++ b/tests/tc_module_scope_op/run.sh
@@ -2,6 +2,6 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file1.d -c59 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 ../../bin/dcd-client $1 file2.d -c44 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc_named_mixin/run.sh
+++ b/tests/tc_named_mixin/run.sh
@@ -2,7 +2,7 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file1.d -c171 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file2.d -c153 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc_opaque_structs/run.sh
+++ b/tests/tc_opaque_structs/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d --symbolLocation -c43 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc_rm_import/run.sh
+++ b/tests/tc_rm_import/run.sh
@@ -2,10 +2,10 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c13 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 ../../bin/dcd-client $1 file.d -R$IMPORTS
 ../../bin/dcd-client $1 file.d -c13 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr
 ../../bin/dcd-client $1 -I$IMPORTS
 ../../bin/dcd-client $1 file.d -c13 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc_scope_mess/run.sh
+++ b/tests/tc_scope_mess/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file1.d -c35 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc_selective_import_list/run.sh
+++ b/tests/tc_selective_import_list/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c13 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc_super_scope/run.sh
+++ b/tests/tc_super_scope/run.sh
@@ -2,10 +2,10 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c28 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c59 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c94 > actual3.txt
-diff actual3.txt expected3.txt
+diff actual3.txt expected3.txt --strip-trailing-cr

--- a/tests/tc_template_param_props/run.sh
+++ b/tests/tc_template_param_props/run.sh
@@ -2,7 +2,7 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c19 > actual1.txt
-diff actual1.txt expected1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr
 
 ../../bin/dcd-client $1 file.d -c37 > actual2.txt
-diff actual2.txt expected2.txt
+diff actual2.txt expected2.txt --strip-trailing-cr

--- a/tests/tc_traits/run.sh
+++ b/tests/tc_traits/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d -c 9 > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc_ufcs_calltip_in_func/run.sh
+++ b/tests/tc_ufcs_calltip_in_func/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 -c293 file.d > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr

--- a/tests/tc_ufcs_completions/run.sh
+++ b/tests/tc_ufcs_completions/run.sh
@@ -2,4 +2,4 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 -c100 -I"$PWD"/fooutils  file.d > actual.txt
-diff actual.txt expected.txt
+diff actual.txt expected.txt --strip-trailing-cr


### PR DESCRIPTION
The proposed changes fix problems with line endings (CRLF instead of LF on Windows), the `s` suffix of the `sleep` command and the different syntax of `stat` on MacOS to make the tests run (mostly) smoothly on MacOS and Windows, too. After those changes, it may be possible to remove the `continue-on-error: true` for the tests on MacOS in the CI pipeline, since they are all passing smoothly.

Windows tests still fail, since there are some more differences in the expected output compared to the produced output, regarding the paths of files. See for example `tc034`. Expected output:

```
/imports/object.d	22
```

Produced output:

```
D:/a/DCD/DCD/tests/imports\\object.d	22
```