### PR TITLE
bump libdparse to 0.21.1

### DIFF
--- a/dsymbol/dub.json
+++ b/dsymbol/dub.json
@@ -6,7 +6,7 @@
 	"targetPath": "build",
 	"targetType": "library",
 	"dependencies": {
-		"libdparse": ">=0.20.0 <0.21.0",
+		"libdparse": ">=0.20.0 <0.22.0",
 		"emsi_containers": "~>0.9.0"
 	}
 }

--- a/dub.json
+++ b/dub.json
@@ -8,7 +8,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     ":dsymbol": "*",
-    "libdparse": ">=0.20.0 <0.21.0",
+    "libdparse": ">=0.20.0 <0.22.0",
     ":common": "*",
     "emsi_containers": "~>0.9.0"
   },


### PR DESCRIPTION
Mainly adds some new syntax parsing support, fixes syntax errors with scope in foreach and others.

Deprecations can be fixed later once we drop libdparse 0.20.0 support