### PR TITLE
upgrade msgpack to ~>1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
 
       - name: Build
         run: |
-          rdmd ./d-test-utils/test_with_package.d $LIBDPARSE_VERSION libdparse -- dub build --build=${{ matrix.build }} --config=client --arch=${{ matrix.arch }}
-          rdmd ./d-test-utils/test_with_package.d $LIBDPARSE_VERSION libdparse -- dub build --build=${{ matrix.build }} --config=server --arch=${{ matrix.arch }}
+          dub build --build=${{ matrix.build }} --config=client --arch=${{ matrix.arch }}
+          dub build --build=${{ matrix.build }} --config=server --arch=${{ matrix.arch }}
 
       # Tests
 
@@ -64,6 +64,12 @@ jobs:
         run: |
           cd dsymbol
           rdmd ../d-test-utils/test_with_package.d $LIBDPARSE_VERSION libdparse -- dub test
+
+      # test that both lowest supplied and highest available libdparse versions are compatible (for DUB users depending on DCD)
+      - name: Test dependency versions
+        run: |
+          rdmd ./d-test-utils/test_with_package.d $LIBDPARSE_VERSION libdparse -- dub build --build=${{ matrix.build }} --config=client --arch=${{ matrix.arch }}
+          rdmd ./d-test-utils/test_with_package.d $LIBDPARSE_VERSION libdparse -- dub build --build=${{ matrix.build }} --config=server --arch=${{ matrix.arch }}
 
       - name: Linux Tests
         if: contains(matrix.os, 'ubuntu')

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ stdout.txt
 # Dub files
 .dub
 dub.selections.json
+!/dub.selections.json

--- a/common/dub.sdl
+++ b/common/dub.sdl
@@ -5,5 +5,5 @@ preBuildCommands "\"$DC\" -run \"$PACKAGE_DIR/dubhash.d\""
 sourcePaths "src"
 importPaths "src"
 
-dependency "msgpack-d" version="1.0.1"
+dependency "msgpack-d" version="~>1.0"
 versions "built_with_dub"

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,0 +1,10 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"dsymbol": "0.14.1",
+		"emsi_containers": "0.9.0",
+		"libdparse": "0.21.1",
+		"msgpack-d": "1.0.4",
+		"stdx-allocator": "2.77.5"
+	}
+}


### PR DESCRIPTION
Fixes msgpack-d deprecations, allows minor bumps upstream, allows DUB dependees to use other msgpack-d versions.