### PR TITLE
downgrade ubuntu version for ABI compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # use older ubuntu / linux version for glibc compatibility
+        os: [ubuntu-20.04, windows-latest, macos-latest]
         dc:
           - ldc-latest
           - dmd-latest
@@ -27,8 +28,8 @@ jobs:
             build: debug
             libdparse-version: min
           # old compiler tests
-          - { os: ubuntu-latest, dc: dmd-2.095.1, libdparse-version: min, build: debug, arch: x86_64 }
-          - { os: ubuntu-latest, dc: ldc-1.25.0, libdparse-version: min, build: debug, arch: x86_64 }
+          - { os: ubuntu-20.04, dc: dmd-2.095.1, libdparse-version: min, build: debug, arch: x86_64 }
+          - { os: ubuntu-20.04, dc: ldc-1.25.0, libdparse-version: min, build: debug, arch: x86_64 }
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # use older ubuntu / linux version for glibc compatibility
+        os: [ubuntu-20.04, windows-latest, macos-latest]
         dc:
           - ldc-latest
         arch:


### PR DESCRIPTION
Build on Ubuntu 20.04 instead of 22.04 for more linux compatibility with pre-built binaries.