### PR TITLE
upgrade to libdparse 0.22.0

### DIFF
--- a/dsymbol/dub.json
+++ b/dsymbol/dub.json
@@ -6,7 +6,7 @@
 	"targetPath": "build",
 	"targetType": "library",
 	"dependencies": {
-		"libdparse": ">=0.20.0 <0.22.0",
+		"libdparse": ">=0.20.0 <0.23.0",
 		"emsi_containers": "~>0.9.0"
 	}
 }

--- a/dsymbol/dub.json
+++ b/dsymbol/dub.json
@@ -6,7 +6,7 @@
 	"targetPath": "build",
 	"targetType": "library",
 	"dependencies": {
-		"libdparse": ">=0.20.0 <0.23.0",
+		"libdparse": ">=0.20.0 <1.0.0",
 		"emsi_containers": "~>0.9.0"
 	}
 }

--- a/dub.json
+++ b/dub.json
@@ -8,7 +8,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     ":dsymbol": "*",
-    "libdparse": ">=0.20.0 <0.22.0",
+    "libdparse": ">=0.20.0 <0.23.0",
     ":common": "*",
     "emsi_containers": "~>0.9.0"
   },

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"dsymbol": "0.14.1",
 		"emsi_containers": "0.9.0",
-		"libdparse": "0.21.1",
+		"libdparse": "0.22.0",
 		"msgpack-d": "1.0.4",
 		"stdx-allocator": "2.77.5"
 	}


### PR DESCRIPTION
for dsymbol I lifted the strict max-version restrictions, as other projects like dscanner depend on it and often don't break. (backwards compatibility with libdparse should stay in for a while anyway)

