### PR TITLE
Improve calltip for functions

### DIFF
--- a/src/dcd/server/autocomplete/util.d
+++ b/src/dcd/server/autocomplete/util.d
@@ -768,7 +768,7 @@ AutocompleteResponse.Completion makeSymbolCompletionInfo(const DSymbol* symbol, 
 		{
 			string retTypeName = symbol.type.type.name;
 			string fnName = symbol.type.name;
-			definition = fnName ~ "()->" ~ retTypeName ~ " " ~ symbol.name;
+			definition = fnName ~ "() -> " ~ retTypeName ~ " " ~ symbol.name;
 		}
 		else
 			definition = symbol.type.name ~ ' ' ~ symbol.name;

--- a/src/dcd/server/autocomplete/util.d
+++ b/src/dcd/server/autocomplete/util.d
@@ -763,7 +763,16 @@ AutocompleteResponse.Completion makeSymbolCompletionInfo(const DSymbol* symbol, 
 {
 	string definition;
 	if ((kind == CompletionKind.variableName || kind == CompletionKind.memberVariableName) && symbol.type)
-		definition = symbol.type.name ~ ' ' ~ symbol.name;
+	{
+		if (symbol.type.kind == CompletionKind.functionName && symbol.type.type)
+		{
+			string retTypeName = symbol.type.type.name;
+			string fnName = symbol.type.name;
+			definition = fnName ~ "()->" ~ retTypeName ~ " " ~ symbol.name;
+		}
+		else
+			definition = symbol.type.name ~ ' ' ~ symbol.name;
+	}
 	else if (kind == CompletionKind.enumMember)
 		definition = symbol.name; // TODO: add enum value to definition string
 	else


### PR DESCRIPTION
Much better, now it shows the return type if available


![Code_Bad0ERFvFt](https://user-images.githubusercontent.com/44361234/218817814-171b3a50-08a1-49fa-b6da-3fa80ba718bf.png)

