### PR TITLE
Ensure no symbols are left out

### DIFF
--- a/dsymbol/src/dsymbol/conversion/package.d
+++ b/dsymbol/src/dsymbol/conversion/package.d
@@ -51,7 +51,7 @@ ScopeSymbolPair generateAutocompleteTrees(const(Token)[] tokens,
 
 	secondPass(first.rootSymbol, first.moduleScope, cache);
 
-	thirdPass(first.moduleScope, cache, cursorPosition);
+	thirdPass(first.rootSymbol, first.moduleScope, cache, cursorPosition);
 
     auto ufcsSymbols = getUFCSSymbolsForCursor(first.moduleScope, tokens, cursorPosition);
 

--- a/dsymbol/src/dsymbol/tests.d
+++ b/dsymbol/src/dsymbol/tests.d
@@ -648,7 +648,7 @@ ScopeSymbolPair generateAutocompleteTrees(string source, string filename, ref Mo
 
 
 	secondPass(first.rootSymbol, first.moduleScope, cache);
-	thirdPass(first.moduleScope, cache, cursorPosition);
+	thirdPass(first.rootSymbol, first.moduleScope, cache, cursorPosition);
 	auto ufcsSymbols = getUFCSSymbolsForCursor(first.moduleScope, tokens, cursorPosition);
 	auto r = first.rootSymbol.acSymbol;
 	typeid(SemanticSymbol).destroy(first.rootSymbol);

--- a/tests/tc717/expected.txt
+++ b/tests/tc717/expected.txt
@@ -1,8 +1,8 @@
 identifiers
-alignof	k			
-init	k			
-mangleof	k			
-max	k			
-min	k			
-sizeof	k			
-stringof	k			
+alignof	k				
+init	k				int
+mangleof	k				
+max	k				int
+min	k				int
+sizeof	k				
+stringof	k				

--- a/tests/tc717/expected.txt
+++ b/tests/tc717/expected.txt
@@ -1,0 +1,8 @@
+identifiers
+alignof	k			
+init	k			
+mangleof	k			
+max	k			
+min	k			
+sizeof	k			
+stringof	k			

--- a/tests/tc717/file.d
+++ b/tests/tc717/file.d
@@ -1,0 +1,15 @@
+struct A
+{
+    B b;
+
+    void test()
+    {
+        auto here = b.inside_b;
+        here.
+    }
+}
+
+struct B
+{
+    int inside_b;
+}

--- a/tests/tc717/run.sh
+++ b/tests/tc717/run.sh
@@ -1,0 +1,5 @@
+set -e
+set -u
+
+../../bin/dcd-client $1 file.d --extended -c88 > actual.txt
+diff actual.txt expected.txt --strip-trailing-cr


### PR DESCRIPTION
Run a lightweight version of secondPass to make sure no symbols are left out

Fixes issue #717 


(This 1st commit only contains the test, to trigger the error, then i'll commit the actual fix)