### PR TITLE
Properly implement pointer types & resolve pointers, arrays and AAs in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,13 +175,19 @@ a tab separated format:
 * definition: function or variable definition string or close approximation for information display purpose
 * symbol location: in which file (or `stdin`) & byte offset this symbol is defined. Separated with a space.
 * documentation: escaped documentation string of this symbol
+* typeOf: resolved type name of this symbol:
+	<!-- the items in list are copied from messages.d -->
+	* For variables, fields, globals, constants: resolved type or empty if unresolved.
+	* For functions: resolved return type or empty if unresolved.
+	* For constructors: may be struct/class name or empty in any case.
+	* Otherwise (probably) empty.
 
 #### Example `--extended` output
 
 	identifiers
 	libraryFunction	f	Tuple!long libraryFunction(string s, string s2)	stdin 190	foobar
-	libraryFunction	f	int* libraryFunction(string s)	stdin 99	Hello\nWorld
-	libraryVariable	v	int libraryVariable	stdin 56	My variable
+	libraryFunction	f	int* libraryFunction(string s)	stdin 99	Hello\nWorld	int*
+	libraryVariable	v	int libraryVariable	stdin 56	My variable	int
 	libreTypes	g		stdin 298
 
 #### Note
@@ -189,6 +195,9 @@ a tab separated format:
 DCD's output will start with "identifiers" when completing at a left paren
 character if the keywords *pragma*, *scope*, *__traits*, *extern*, or *version*
 were just before the paren.
+
+Types in the calltips and typeOf column may not be complete, e.g. missing
+template parameters or typeof expressions, etc.
 
 ### Parenthesis completion
 

--- a/common/src/dcd/common/messages.d
+++ b/common/src/dcd/common/messages.d
@@ -152,6 +152,14 @@ struct AutocompleteResponse
 		 * Documentation associated with this symbol.
 		 */
 		string documentation;
+		// when changing the behavior here, update README.md
+		/**
+		 * For variables, fields, globals, constants: resolved type or empty if unresolved.
+		 * For functions: resolved return type or empty if unresolved.
+		 * For constructors: may be struct/class name or empty in any case.
+		 * Otherwise (probably) empty.
+		 */
+		string typeOf;
 	}
 
 	/**

--- a/dsymbol/src/dsymbol/builtin/symbols.d
+++ b/dsymbol/src/dsymbol/builtin/symbols.d
@@ -41,6 +41,11 @@ TTree!(DSymbol*, SymbolsAllocator, true, "a < b") classSymbols;
 TTree!(DSymbol*, SymbolsAllocator, true, "a < b") enumSymbols;
 
 /**
+ * Pointer properties (when not implicitly dereferencing)
+ */
+TTree!(DSymbol*, SymbolsAllocator, true, "a < b") pointerSymbols;
+
+/**
  * Variadic template parameters properties
  */
 DSymbol* variadicTmpParamSymbol;
@@ -191,6 +196,12 @@ static this()
 	aggregateSymbols.insert(stringof_);
 	aggregateSymbols.insert(init);
 
+	pointerSymbols.insert(mangleof_);
+	pointerSymbols.insert(alignof_);
+	pointerSymbols.insert(sizeof_);
+	pointerSymbols.insert(stringof_);
+	pointerSymbols.insert(init);
+
 	classSymbols.insert(makeSymbol("classinfo", CompletionKind.variableName));
 	classSymbols.insert(tupleof);
 	classSymbols.insert(makeSymbol("__vptr", CompletionKind.variableName));
@@ -283,6 +294,7 @@ static ~this()
 	destroy(aggregateSymbols);
 	destroy(classSymbols);
 	destroy(enumSymbols);
+	destroy(pointerSymbols);
 
 	foreach (sym; symbolsMadeHere[])
 		destroy(*sym);

--- a/dsymbol/src/dsymbol/conversion/first.d
+++ b/dsymbol/src/dsymbol/conversion/first.d
@@ -1129,9 +1129,7 @@ private:
 
 		foreach (suffix; type.typeSuffixes)
 		{
-			if (suffix.star != tok!"")
-				continue;
-			else if (suffix.type)
+			if (suffix.type)
 				lookup.breadcrumbs.insert(ASSOC_ARRAY_SYMBOL_NAME);
 			else if (suffix.array)
 				lookup.breadcrumbs.insert(ARRAY_SYMBOL_NAME);

--- a/dsymbol/src/dsymbol/symbol.d
+++ b/dsymbol/src/dsymbol/symbol.d
@@ -445,6 +445,43 @@ struct DSymbol
 	/// Protection level for this symbol
 	IdType protection;
 
+	string formatType(string suffix = "") const
+	{
+		if (kind == CompletionKind.functionName)
+		{
+			if (type) // try to give return type symbol
+				return type.formatType;
+			else // null if unresolved, user can manually pick .name or .callTip if needed
+				return null;
+		}
+		else if (name == POINTER_SYMBOL_NAME)
+		{
+			if (!type)
+				return suffix ~ "*";
+			else
+				return type.formatType(suffix ~ "*");
+		}
+		else if (name == ARRAY_SYMBOL_NAME)
+		{
+			if (!type)
+				return suffix ~ "[]";
+			else
+				return type.formatType(suffix ~ "[]");
+		}
+		else if (name == ASSOC_ARRAY_SYMBOL_NAME)
+		{
+			// TODO: include AA key type
+			if (!type)
+				return suffix ~ "[...]";
+			else
+				return type.formatType(suffix ~ "[...]");
+		}
+		else
+		{
+			// TODO: include template parameters
+			return name ~ suffix;
+		}
+	}
 }
 
 /**

--- a/dsymbol/src/dsymbol/symbol.d
+++ b/dsymbol/src/dsymbol/symbol.d
@@ -131,6 +131,8 @@ enum SymbolQualifier : ubyte
 	func,
 	/// Selective import
 	selectiveImport,
+	/// The symbol is a pointer
+	pointer,
 }
 
 /**
@@ -227,6 +229,11 @@ struct DSymbol
 		if (visited.contains(cast(size_t) &this))
 			return;
 		visited.insert(cast(size_t) &this);
+
+		// pointers are implicitly dereferenced on members (a single layer)
+		if (qualifier == SymbolQualifier.pointer
+			&& this.type.qualifier != SymbolQualifier.pointer)
+			return type.getParts!OR(name, app, visited, onlyOne);
 
 		if (name is null)
 		{
@@ -427,9 +434,13 @@ struct DSymbol
 	// dfmt off
 	mixin(bitfields!(bool, "ownType", 1,
 		bool, "skipOver", 1,
-		bool, "isPointer", 1,
-		ubyte, "", 5));
+		ubyte, "", 6));
 	// dfmt on
+
+	deprecated bool isPointer()
+	{
+		return qualifier == SymbolQualifier.pointer;
+	}
 
 	/// Protection level for this symbol
 	IdType protection;

--- a/dsymbol/src/dsymbol/tests.d
+++ b/dsymbol/src/dsymbol/tests.d
@@ -217,8 +217,8 @@ unittest
 	};
 	ScopeSymbolPair pair = generateAutocompleteTrees(source, cache);
 	DSymbol* meaningOfLife = pair.symbol.getFirstPartNamed(istring("meaningOfLife"));
-	writeln(meaningOfLife.type.name);
-	assert(meaningOfLife.type.name == "int");
+	writeln(meaningOfLife.type.formatType);
+	assert(meaningOfLife.type.formatType == "int*");
 }
 
 

--- a/src/dcd/client/client.d
+++ b/src/dcd/client/client.d
@@ -396,7 +396,8 @@ void printCompletionResponse(ref const AutocompleteResponse response, bool exten
 						completion.kind == char.init ? "" : "" ~ completion.kind,
 						completion.definition,
 						completion.symbolFilePath.length ? completion.symbolFilePath ~ " " ~ completion.symbolLocation.to!string : "",
-						completion.documentation
+						completion.documentation,
+						completion.typeOf
 					));
 				else
 					app.put(makeTabSeparated(completion.identifier, "" ~ completion.kind));

--- a/src/dcd/server/autocomplete/complete.d
+++ b/src/dcd/server/autocomplete/complete.d
@@ -701,5 +701,6 @@ do
 	auto completion = makeSymbolCompletionInfo(symbol, char.init);
 	completion.identifier = "this";
 	completion.definition = generatedStructConstructorCalltip;
+	completion.typeOf = symbol.name;
 	return completion;
 }

--- a/src/dcd/server/autocomplete/util.d
+++ b/src/dcd/server/autocomplete/util.d
@@ -381,7 +381,8 @@ DSymbol*[] getSymbolsByTokenChain(T)(Scope* completionScope,
 		case tok!"[":
 			if (symbols.length == 0)
 				break loop;
-			if (symbols[0].qualifier == SymbolQualifier.array)
+			if (symbols[0].qualifier == SymbolQualifier.array
+				|| symbols[0].qualifier == SymbolQualifier.pointer)
 			{
 				skip(tok!"[", tok!"]");
 				if (!isSliceExpression(tokens, i))

--- a/tests/tc059/expected1.txt
+++ b/tests/tc059/expected1.txt
@@ -1,4 +1,5 @@
 identifiers
-libraryFunction	f	Tuple!long libraryFunction(string s, string s2)	stdin 190	foobar
-libraryFunction	f	int* libraryFunction(string s)	stdin 99	Hello\nWorld
-libraryVariable	v	int libraryVariable	stdin 56	My variable
+libraryFunction	f	Tuple!long libraryFunction(string s, string s2)	stdin 223	foobar	
+libraryFunction	f	int* libraryFunction(string s)	stdin 132	Hello\nWorld	int*
+libraryVariable	v	int libraryVariable	stdin 56	My variable	int
+libraryVariable2	v	int* libraryVariable2	stdin 88	My variable	int*

--- a/tests/tc059/file.d
+++ b/tests/tc059/file.d
@@ -5,6 +5,8 @@ void main(string[] args)
 
 /// My variable
 int libraryVariable;
+/// ditto
+int* libraryVariable2;
 
 /// Hello
 /// World

--- a/tests/tc061/expected1.txt
+++ b/tests/tc061/expected1.txt
@@ -1,3 +1,3 @@
 calltips
-libraryFunction		Tuple!long libraryFunction(string s, string s2)	stdin 166	foobar
-libraryFunction		int* libraryFunction(string s)	stdin 75	Hello\nWorld
+libraryFunction		Tuple!long libraryFunction(string s, string s2)	stdin 166	foobar	
+libraryFunction		int* libraryFunction(string s)	stdin 75	Hello\nWorld	int*

--- a/tests/tc_extended_ditto/expected1.txt
+++ b/tests/tc_extended_ditto/expected1.txt
@@ -1,3 +1,3 @@
 identifiers
-foo	f	void foo()	stdin 26	my documentation
-foo	f	void foo(int i)	stdin 49	my documentation
+foo	f	void foo()	stdin 26	my documentation	void
+foo	f	void foo(int i)	stdin 49	my documentation	void

--- a/tests/tc_extended_types/expected1.txt
+++ b/tests/tc_extended_types/expected1.txt
@@ -1,0 +1,2 @@
+identifiers
+bar	v	foo bar	stdin 92		

--- a/tests/tc_extended_types/file.d
+++ b/tests/tc_extended_types/file.d
@@ -1,0 +1,12 @@
+/// my documentation
+struct S
+{
+	T foo(T)() { return T.init; }
+}
+
+void test()
+{
+	S s;
+	auto bar = s.foo!int();
+	bar
+}

--- a/tests/tc_extended_types/run.sh
+++ b/tests/tc_extended_types/run.sh
@@ -1,0 +1,5 @@
+set -e
+set -u
+
+../../bin/dcd-client $1 file.d -x -c115 > actual1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc_import_symbol_list/run.sh
+++ b/tests/tc_import_symbol_list/run.sh
@@ -2,5 +2,5 @@ set -e
 set -u
 
 ../../bin/dcd-client $1 file.d --extended -I"$PWD"/newpackage -c$(wc -c < file.d) > actual1.txt
-echo -e "identifiers\nSomeStruct\ts\t\t$PWD/newpackage/newmodule.d 26\t" > expected1.txt
+echo -e "identifiers\nSomeStruct\ts\t\t$PWD/newpackage/newmodule.d 26\t\t" > expected1.txt
 diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc_pointer_type_printing/expected1.txt
+++ b/tests/tc_pointer_type_printing/expected1.txt
@@ -1,0 +1,14 @@
+identifiers
+itemA	v	S itemA	stdin 44		S
+itemB	v	S* itemB	stdin 55		S*
+itemC	v	S[]* itemC	stdin 68		S[]*
+itemD	v	S[][]* itemD	stdin 83		S[][]*
+itemE	v	S[][]*[] itemE	stdin 100		S[][]*[]
+itemF	v	S[][]*[][] itemF	stdin 119		S[][]*[][]
+itemG	v	S[][...]*[][] itemG	stdin 141		S[][...]*[][]
+itemH	v	S[][]*[...][] itemH	stdin 163		S[][]*[...][]
+itemI	v	S[...][]*[...][] itemI	stdin 188		S[...][]*[...][]
+itemJ	v	S[...]*[]*[...][] itemJ	stdin 214		S[...]*[]*[...][]
+itemK	v	S[...]*[]**[...][] itemK	stdin 241		S[...]*[]**[...][]
+itemL	v	S[...]*[]*[...]*[] itemL	stdin 268		S[...]*[]*[...]*[]
+itemM	v	S[...]*[]*[...]*[]* itemM	stdin 296		S[...]*[]*[...]*[]*

--- a/tests/tc_pointer_type_printing/file.d
+++ b/tests/tc_pointer_type_printing/file.d
@@ -1,0 +1,23 @@
+struct S
+{
+	int member;
+}
+
+void test()
+{
+	S itemA;
+	S* itemB;
+	S[]* itemC;
+	S[][]* itemD;
+	S[][]*[] itemE;
+	S[][]*[][] itemF;
+	S[][int]*[][] itemG;
+	S[][]*[int][] itemH;
+	S[int][]*[int][] itemI;
+	S[int]*[]*[int][] itemJ;
+	S[int]*[]**[int][] itemK;
+	S[int]*[]*[int]*[] itemL;
+	S[int]*[]*[int]*[]* itemM;
+
+	item
+}

--- a/tests/tc_pointer_type_printing/run.sh
+++ b/tests/tc_pointer_type_printing/run.sh
@@ -1,0 +1,5 @@
+set -e
+set -u
+
+../../bin/dcd-client $1 file.d -x -c309 > actual1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc_pointers/expected1.txt
+++ b/tests/tc_pointers/expected1.txt
@@ -1,0 +1,30 @@
+identifiers
+alignof	k				
+init	k				
+mangleof	k				
+member	v	int member	stdin 16		int
+sizeof	k				
+stringof	k				
+tupleof	k				
+identifiers
+alignof	k				
+init	k				
+mangleof	k				
+member	v	int member	stdin 16		int
+sizeof	k				
+stringof	k				
+tupleof	k				
+identifiers
+alignof	k				
+init	k				
+mangleof	k				
+sizeof	k				
+stringof	k				
+identifiers
+alignof	k				
+init	k				
+mangleof	k				
+member	v	int member	stdin 16		int
+sizeof	k				
+stringof	k				
+tupleof	k				

--- a/tests/tc_pointers/file.d
+++ b/tests/tc_pointers/file.d
@@ -1,0 +1,28 @@
+struct S
+{
+	int member;
+}
+
+void test()
+{
+	S itemA;
+	itemA.
+}
+
+void test2()
+{
+	S* itemPtr = &itemA;
+	itemPtr.
+}
+
+void test3()
+{
+	S** itemPtrPtr = &itemA;
+	itemPtrPtr.
+}
+
+void test3()
+{
+	S** itemPtrPtr = &itemA;
+	itemPtrPtr[10].
+}

--- a/tests/tc_pointers/run.sh
+++ b/tests/tc_pointers/run.sh
@@ -1,0 +1,8 @@
+set -e
+set -u
+
+../../bin/dcd-client $1 file.d -x -c58 > actual1.txt
+../../bin/dcd-client $1 file.d -x -c108 >> actual1.txt
+../../bin/dcd-client $1 file.d -x -c165 >> actual1.txt
+../../bin/dcd-client $1 file.d -x -c226 >> actual1.txt
+diff actual1.txt expected1.txt --strip-trailing-cr

--- a/tests/tc_recursive_public_import/run.sh
+++ b/tests/tc_recursive_public_import/run.sh
@@ -4,5 +4,5 @@ set -u
 echo "import: $PWD/testing"
 
 ../../bin/dcd-client $1 app.d --extended -I $PWD/ -c50 > actual.txt
-echo -e "identifiers\nworld\tv\tWorld world\t$PWD/testing/a.d 77\t" > expected.txt
+echo -e "identifiers\nworld\tv\tWorld world\t$PWD/testing/a.d 77\t\tWorld" > expected.txt
 diff actual.txt expected.txt --strip-trailing-cr


### PR DESCRIPTION
supersedes PR fix #715 

@ryuukk this supersedes that PR you made that extended the type details to `foo -> T` syntax. I decided to only have the resolved type here, there is a fallback to use the function name on unknown types though. We could probably expose this information elsewhere though and show it somehow in serve-d.

@vushu there is a single UFCS line fix in here, which you probably want to include in your PR as well

If any of you could also review, that would be nice.