### PR TITLE
Removing ufcs for non constrained template

### DIFF
--- a/dsymbol/src/dsymbol/tests.d
+++ b/dsymbol/src/dsymbol/tests.d
@@ -710,8 +710,7 @@ unittest
 		// position of variable life 
 		size_t cursorPos = 82;
 		auto pair = generateAutocompleteTreesProd(ufcsTemplateExampleCode, randomDFilename, cursorPos, cache);
-		assert(pair.ufcsSymbols.length > 0);
-		assert(pair.ufcsSymbols[0].name == "increment");
+		assert(pair.ufcsSymbols.length == 0);
 
 	}
 

--- a/dsymbol/src/dsymbol/ufcs.d
+++ b/dsymbol/src/dsymbol/ufcs.d
@@ -279,10 +279,6 @@ private bool matchAliasThis(const(DSymbol)* beforeDotType, const(DSymbol)* incom
     return isCallableWithArg(incomingSymbol, beforeDotType.aliasThisSymbols.front.type, false, recursionDepth);
 }
 
-bool isNonConstrainedTemplate(const(DSymbol)* incomingSymbol){
-    return incomingSymbol.functionParameters.front.type !is null && incomingSymbol.functionParameters.front.type.kind is CompletionKind.typeTmpParam; 
-}
-
 /**
  * Params:
  *     incomingSymbol = the function symbol to check if it is valid for UFCS with `beforeDotType`.
@@ -305,7 +301,6 @@ bool isCallableWithArg(const(DSymbol)* incomingSymbol, const(DSymbol)* beforeDot
     if (incomingSymbol.kind is CompletionKind.functionName && !incomingSymbol.functionParameters.empty && incomingSymbol.functionParameters.front.type)
     {
         return beforeDotType is incomingSymbol.functionParameters.front.type
-            || isNonConstrainedTemplate(incomingSymbol)
             || willImplicitBeUpcasted(beforeDotType, incomingSymbol)
             || matchAliasThis(beforeDotType, incomingSymbol, recursionDepth);
 


### PR DESCRIPTION
@WebFreak001 
I thought that CompletionKind.tmpTmpParam respected if statements before the function body, it states `symbol.d:105` type template parameter when no constraint, which should not included if's before function body?

so I thought for that the example below was not included.
```
bool isSorted(alias less = "a < b", Range)(Range r)
if (isForwardRange!(Range)
{
...
}
```



Since I mistook that, it is probably best to disable this feature.

Could we somehow use the compiler or dmd-fe to deduce template constraints?

