### PR TITLE
Fuzzy matching instead of startsWith for filtering

### DIFF
--- a/dsymbol/dub.json
+++ b/dsymbol/dub.json
@@ -7,6 +7,7 @@
 	"targetType": "library",
 	"dependencies": {
 		"libdparse": ">=0.20.0 <1.0.0",
-		"emsi_containers": "~>0.9.0"
+		"emsi_containers": "~>0.9.0",
+		"fuzzymatch": "~>1.0"
 	}
 }

--- a/dsymbol/src/dsymbol/ufcs.d
+++ b/dsymbol/src/dsymbol/ufcs.d
@@ -231,12 +231,12 @@ private DSymbol*[] getUFCSSymbolsForDotCompletion(const(DSymbol)* symbolType, Sc
     // local appender
     FilteredAppender!((DSymbol* a) =>
             a.isCallableWithArg(symbolType)
-            && toUpper(a.name.data).startsWith(toUpper(partial)),
+            && prettyFuzzyMatch(a.name.data, partial),
         DSymbol*[]) localAppender;
     // global appender
     FilteredAppender!((DSymbol* a) =>
             a.isCallableWithArg(symbolType, true)
-            && toUpper(a.name.data).startsWith(toUpper(partial)),
+            && prettyFuzzyMatch(a.name.data, partial),
         DSymbol*[]) globalAppender;
 
     getUFCSSymbols(localAppender, globalAppender, completionScope, cursorPosition);

--- a/dsymbol/src/dsymbol/utils.d
+++ b/dsymbol/src/dsymbol/utils.d
@@ -153,3 +153,19 @@ unittest
 	i = skipParenReverseBefore(t, i, tok!")", tok!"(");
 	assert(i == 1);
 }
+
+/// Checks if `doesThis` roughly starts with `matchThis`, case-insensitive
+bool prettyFuzzyMatch(scope const(char)[] doesThis, scope const(char)[] matchThis) @safe pure nothrow @nogc
+{
+	import fuzzymatch;
+
+	if (!matchThis.length)
+		return true;
+
+	// return false if identifier starts with _, but search doesn't or vice-versa
+	if (doesThis.length && (doesThis[0] == '_' && matchThis[0] != '_'
+		|| doesThis[0] != '_' && matchThis[0] == '_'))
+		return false;
+
+	return fuzzyMatchesString(doesThis, matchThis);
+}

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -3,6 +3,7 @@
 	"versions": {
 		"dsymbol": "0.14.1",
 		"emsi_containers": "0.9.0",
+		"fuzzymatch": "1.0.0",
 		"libdparse": "0.22.0",
 		"msgpack-d": "1.0.4",
 		"stdx-allocator": "2.77.5"

--- a/tests/tc021/expected.txt
+++ b/tests/tc021/expected.txt
@@ -3,3 +3,6 @@ idouble	k
 ifloat	k
 int	k
 ireal	k
+string	l
+uint	k
+void	k

--- a/tests/tc029/expected1.txt
+++ b/tests/tc029/expected1.txt
@@ -6,3 +6,6 @@ cfloat	k
 char	k
 complicatedLess	l
 creal	k
+dchar	k
+ucent	k
+wchar	k

--- a/tests/tc051/expected.txt
+++ b/tests/tc051/expected.txt
@@ -1,3 +1,5 @@
 identifiers
 Foo	s
+cfloat	k
 float	k
+ifloat	k

--- a/tests/tc_accesschain_type/expected.txt
+++ b/tests/tc_accesschain_type/expected.txt
@@ -1,2 +1,7 @@
 identifiers
+alignof	k
 foo	f
+mangleof	k
+sizeof	k
+stringof	k
+tupleof	k

--- a/tests/tc_complete_kw/expected3.txt
+++ b/tests/tc_complete_kw/expected3.txt
@@ -1,2 +1,3 @@
 identifiers
+init	k
 internal	v

--- a/tests/tc_extended_ditto/expected1.txt
+++ b/tests/tc_extended_ditto/expected1.txt
@@ -1,3 +1,6 @@
 identifiers
+cfloat	k				cfloat
+float	k				float
 foo	f	void foo()	stdin 26	my documentation	void
 foo	f	void foo(int i)	stdin 49	my documentation	void
+ifloat	k				ifloat


### PR DESCRIPTION
Experimental, subject to change

This way, when you have a function `parseJsonString` and you only type `parseString` or search for `jsonString`, you will find the symbols.

Note that without the IDE/editor sorting imports in a decent manner, this will quickly overwhelm users auto-complete.

With VSCode's default sorting and filtering this works very well though.

Feel free to give this PR a try and give your feedback. (cc @ryuukk @vushu)

Ideally for code cleanliness, prettyFuzzyMatch should not be part of dsymbol, but only of dcd.

Side-note for UFCS in dsymbol causing the fuzzymatch dependency in there:

I think we should move out the UFCS auto-complete / cursor token matching code out of dsymbol into DCD, and only let dsymbol do all the UFCS processing, e.g returning UFCS symbols joined into the regular symbols using the usual (or to-be-created) listing APIs. (indicating the UFCS symbols just using flags)

I noticed that the UFCS matcher also just started to reimplement bunch of stuff from DCD and still misses things, such as recognizing `int` as partially typed identifier. Splitting the matcher from UFCS symbol generation and moving just the matcher into DCD's existing matching code would deduplicate a lot there.