### PR TITLE
prepare for libdparse changes 1/2

### DIFF
--- a/dsymbol/src/dsymbol/tests.d
+++ b/dsymbol/src/dsymbol/tests.d
@@ -335,6 +335,8 @@ unittest
 		DSymbol* S = pair.symbol.getFirstPartNamed(internString("S"));
 		DSymbol* b = pair.symbol.getFirstPartNamed(internString("b"));
 		assert(S);
+		assert(b);
+		assert(b.type);
 		assert(b.type is S);
 	}
 	{
@@ -343,6 +345,8 @@ unittest
 		DSymbol* S = pair.symbol.getFirstPartNamed(internString("S"));
 		DSymbol* b = pair.symbol.getFirstPartNamed(internString("b"));
 		assert(S);
+		assert(b);
+		assert(b.type);
 		assert(b.type is S);
 	}
 	{
@@ -351,6 +355,8 @@ unittest
 		DSymbol* S = pair.symbol.getFirstPartNamed(internString("S"));
 		DSymbol* b = pair.symbol.getFirstPartNamed(internString("b"));
 		assert(S);
+		assert(b);
+		assert(b.type);
 		assert(b.type.type is S);
 	}
 	{
@@ -359,6 +365,8 @@ unittest
 		DSymbol* S = pair.symbol.getFirstPartNamed(internString("S"));
 		DSymbol* b = pair.symbol.getFirstPartNamed(internString("b"));
 		assert(S);
+		assert(b);
+		assert(b.type);
 		assert(b.type.name == ARRAY_SYMBOL_NAME);
 		assert(b.type.type is S);
 	}
@@ -368,6 +376,7 @@ unittest
 		DSymbol* S = pair.symbol.getFirstPartNamed(internString("S"));
 		DSymbol* b = pair.symbol.getFirstPartNamed(internString("b"));
 		assert(S);
+		assert(b);
 		assert(b.type is S);
 	}
 }


### PR DESCRIPTION
pairs with https://github.com/dlang-community/libdparse/pull/491

reduces RAM usage of DCD by about a third (needs libdparse update first)

I would likely want to bump libdparse to 1.0.0 once we have the big AST nodes flattened and memory optimized.