### PR TITLE
Fix ArraySliceError in complete.d when there is no paren.

### DIFF
--- a/src/dcd/server/autocomplete/complete.d
+++ b/src/dcd/server/autocomplete/complete.d
@@ -361,7 +361,12 @@ CalltipHint getCalltipHint(T)(T beforeTokens, out size_t parenIndex)
 	// evaluate at comma case
 	if (beforeTokens.isComma)
 	{
-		parenIndex = beforeTokens.goBackToOpenParen;
+		size_t tmp = beforeTokens.goBackToOpenParen;
+		if(tmp == size_t.max){
+			return CalltipHint.regularArguments;
+		}
+		parenIndex = tmp;
+
 		// check if we are actually a "!("
 		if (beforeTokens[0 .. parenIndex].isTemplateBangParen)
 		{


### PR DESCRIPTION
`goBackToOpenParen` can return `size_t.max`, which the calling code in `getCalltipHint` did not handle (and accidentally returns via an `out` parameter).

Check for this case so we don't get an array slice error.


Before this patch I would get a crash after typing the comma in code like this:

```d
enum Foo {
    X,
}
```

```
src/dcd/server/autocomplete/complete.d:366 pure nothrow @nogc @safe dcd.server.autocomplete.complete.CalltipHint dcd.server.autocomplete.complete.getCalltipHint!(std.range.SortedRange!(const(std.experimental.lexer.TokenStructure!(ubyte, "import dparse.lexer:TokenTriviaFields,TriviaToken; mixin TokenTriviaFields;").TokenStructure)[], "a < b", 0).SortedRange).getCalltipHint(std.range.SortedRange!(const(std.experimental.lexer.TokenStructure!(ubyte, "import dparse.lexer:TokenTriviaFields,TriviaToken; mixin TokenTriviaFields;").TokenStructure)[], "a < b", 0).SortedRange, out ulong) [0x1006ebf3f]
src/dcd/server/autocomplete/complete.d:140 dcd.common.messages.AutocompleteResponse dcd.server.autocomplete.complete.complete(const(dcd.common.messages.AutocompleteRequest), ref dsymbol.modulecache.ModuleCache) [0x1006a812b]
src/dcd/server/main.d:337 pure @nogc @safe dcd.common.messages.AutocompleteResponse dcd.server.main.runServer(immutable(char)[][]).__dgliteral66() [0x1006a777b]
src/dcd/server/main.d:362 void dcd.server.main.trySendResponse(std.socket.Socket, lazy dcd.common.messages.AutocompleteResponse, lazy immutable(char)[]) [0x1006a6ecb]
src/dcd/server/main.d:337 int dcd.server.main.runServer(immutable(char)[][]) [0x1006a46f3]
src/dcd/server/main.d:63 _Dmain [0x1006a06a3]
```