### PR TITLE
fix(env): change the environment to be /usr/bin/env bash

### DIFF
--- a/makefile
+++ b/makefile
@@ -13,7 +13,7 @@ LDC := ldc2
 DPARSE_DIR := libdparse
 DSYMBOL_DIR := dsymbol
 
-SHELL:=/bin/bash
+SHELL:=/usr/bin/env bash
 
 githash:
 	@mkdir -p bin

--- a/tests/extra/tc_ufcs_all_kinds/run.sh
+++ b/tests/extra/tc_ufcs_all_kinds/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -z "${DC:-}" ]; then
 	DC=dmd

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 RED="\033[31m"
 GREEN="\033[32m"
 YELLOW="\033[33m"


### PR DESCRIPTION
Changed the places using `/bin/bash` to `/usr/bin/env bash`. This is important for OS'es which do not have bash located here such as NixOS.