### PR TITLE
Add support for extended output when requesting symbol's documentation

### DIFF
--- a/src/dcd/client/client.d
+++ b/src/dcd/client/client.d
@@ -250,7 +250,7 @@ int runClient(string[] args)
 	else if (getIdentifier)
 		printIdentifierResponse(response);
 	else if (doc)
-		printDocResponse(response);
+		printDocResponse(response, fullOutput);
 	else if (search !is null)
 		printSearchResponse(response);
 	else if (localUse)
@@ -359,10 +359,14 @@ Socket createSocket(string socketFile, ushort port)
 	return socket;
 }
 
-void printDocResponse(ref const AutocompleteResponse response)
+void printDocResponse(ref const AutocompleteResponse response, bool extended)
 {
-	import std.algorithm : each;
-	response.completions.each!(a => a.documentation.escapeConsoleOutputString(true).writeln);
+	foreach (ref completion; response.completions)
+    {
+    	if (extended)
+            writeln(completion.definition);
+        writeln(completion.documentation.escapeConsoleOutputString(true));
+    }
 }
 
 void printIdentifierResponse(ref const AutocompleteResponse response)

--- a/src/dcd/client/client.d
+++ b/src/dcd/client/client.d
@@ -362,11 +362,11 @@ Socket createSocket(string socketFile, ushort port)
 void printDocResponse(ref const AutocompleteResponse response, bool extended)
 {
 	foreach (ref completion; response.completions)
-    {
-    	if (extended)
-            writeln(completion.definition);
-        writeln(completion.documentation.escapeConsoleOutputString(true));
-    }
+	{
+		if (extended)
+			writeln(completion.definition);
+		writeln(completion.documentation.escapeConsoleOutputString(true));
+	}
 }
 
 void printIdentifierResponse(ref const AutocompleteResponse response)

--- a/src/dcd/server/autocomplete/doc.d
+++ b/src/dcd/server/autocomplete/doc.d
@@ -62,7 +62,7 @@ public AutocompleteResponse getDoc(const AutocompleteRequest request,
 				continue;
 			firstSymbol = false;
 
-			AutocompleteResponse.Completion c;
+			AutocompleteResponse.Completion c = makeSymbolCompletionInfo(symbol, symbol.kind);
 			c.documentation = symbol.doc;
 			response.completions ~= c;
 		}


### PR DESCRIPTION
This allows to get the symbol definition, reducing the need of a extra request/computation when passing: ``--extended | -x``

