### PR TITLE
Save memory by removing argNames from DSymbol

### DIFF
--- a/dsymbol/src/dsymbol/conversion/first.d
+++ b/dsymbol/src/dsymbol/conversion/first.d
@@ -1006,7 +1006,6 @@ private:
 						break;
 					}
 				}
-				currentSymbol.acSymbol.argNames.insert(parameter.acSymbol.name);
 
 				currentSymbol.acSymbol.functionParameters ~= parameter.acSymbol;
 

--- a/dsymbol/src/dsymbol/symbol.d
+++ b/dsymbol/src/dsymbol/symbol.d
@@ -386,11 +386,6 @@ struct DSymbol
 
 	// Is alias this symbols
 	DSymbol*[] aliasThisSymbols;
-	/**
-	 * Names of function arguments
-	 */
-	// TODO: remove since we have function arguments
-	UnrolledList!(istring) argNames;
 
 	/**
 	 * Function parameter symbols


### PR DESCRIPTION
As per the comment, it is no longer needed

Before:
![SystemInformer_wiL04IjiWE](https://github.com/dlang-community/DCD/assets/44361234/f0398c9e-0534-4fa7-a7c0-00566dc958ab)


After:
![SystemInformer_r1SZfzCiF7](https://github.com/dlang-community/DCD/assets/44361234/fe5865f5-fa89-49f2-b7e2-8716387cf168)


