### PR TITLE
Fix build on OpenBSD, NetBSD and DragonflyBSD

### DIFF
--- a/common/src/dcd/common/socket.d
+++ b/common/src/dcd/common/socket.d
@@ -27,6 +27,9 @@ version (OSX) version = haveUnixSockets;
 version (linux) version = haveUnixSockets;
 version (BSD) version = haveUnixSockets;
 version (FreeBSD) version = haveUnixSockets;
+version (OpenBSD) version = haveUnixSockets;
+version (NetBSD) version = haveUnixSockets;
+version (DragonflyBSD) version = haveUnixSockets;
 
 enum DEFAULT_PORT_NUMBER = 9166;
 

--- a/makefile
+++ b/makefile
@@ -13,8 +13,6 @@ LDC := ldc2
 DPARSE_DIR := libdparse
 DSYMBOL_DIR := dsymbol
 
-SHELL:=/usr/bin/env bash
-
 githash:
 	@mkdir -p bin
 	git describe --tags > bin/githash.txt
@@ -37,7 +35,6 @@ CLIENT_SRC := \
 DMD_CLIENT_FLAGS := -Imsgpack-d/src\
 	-Imsgpack-d/src\
 	-Jbin\
-	-inline\
 	-O\
 	-wi\
 	-ofbin/dcd-client
@@ -55,6 +52,10 @@ LDC_CLIENT_FLAGS := -Imsgpack-d/src\
 	-O5\
 	-oq\
 	-of=bin/dcd-client
+
+ifneq ($(shell uname), OpenBSD)
+	override DMD_CLIENT_FLAGS += -inline
+endif
 
 override DMD_CLIENT_FLAGS += $(DFLAGS)
 override LDC_CLIENT_FLAGS += $(DFLAGS)
@@ -76,7 +77,6 @@ DMD_SERVER_FLAGS := -Icontainers/src\
 	-wi\
 	-O\
 	-release\
-	-inline\
 	-ofbin/dcd-server
 
 DEBUG_SERVER_FLAGS := -Icontainers/src\
@@ -105,6 +105,10 @@ LDC_SERVER_FLAGS := -Icontainers/src\
 	-J=bin\
 	-O5\
 	-release
+
+ifneq ($(shell uname), OpenBSD)
+	DMD_SERVER_FLAGS += -inline
+endif
 
 override DMD_SERVER_FLAGS += $(DFLAGS)
 override LDC_SERVER_FLAGS += $(DFLAGS)

--- a/src/dcd/server/server.d
+++ b/src/dcd/server/server.d
@@ -35,6 +35,9 @@ enum CONFIG_FILE_NAME = "dcd.conf";
 version(linux) version = useXDG;
 version(BSD) version = useXDG;
 version(FreeBSD) version = useXDG;
+version(OpenBSD) version = useXDG;
+version(NetBSD) version = useXDG;
+version(DragonflyBSD) version = useXDG;
 version(OSX) version = useXDG;
 
 /**


### PR DESCRIPTION
Added extra version statements for OpenBSD, NetBSD and DragonflyBSD, as these are not included in the BSD version identifier.

Also removed the line `SHELL:=/usr/bin/env bash` from the top of the makefile because most BSDs don't include bash in the base system, and the build doesn't need it anyway.

On OpenBSD, using -inline with dmd causes the compiler to crash because of insufficient memory (with 8 GB), so I added a couple of ifneq's to use -inline only if the build is not running on OpenBSD (or we could just remove -inline entirely...)