### PR TITLE
fix getSymbolsForCompletion raise exception

### DIFF
--- a/src/dcd/server/autocomplete/util.d
+++ b/src/dcd/server/autocomplete/util.d
@@ -147,7 +147,8 @@ SymbolStuff getSymbolsForCompletion(const AutocompleteRequest request,
 	auto expression = getExpression(beforeTokens);
 	auto symbols = getSymbolsByTokenChain(pair.scope_, expression,
 		request.cursorPosition, type);
-	if (symbols.length == 0 && doUFCSSearch(stringToken(beforeTokens.front), stringToken(beforeTokens.back))) {
+	if (symbols.length == 0 && !beforeTokens.empty &&
+		doUFCSSearch(stringToken(beforeTokens.front), stringToken(beforeTokens.back))) {
 		// Let search for UFCS, since we got no hit
 		symbols ~= getSymbolsByTokenChain(pair.scope_, getExpression([beforeTokens.back]), request.cursorPosition, type);
 	}


### PR DESCRIPTION
should first check if the range `beforeTokens` is empty.

```
core.exception.AssertError@/usr/include/dmd/phobos/std/range/primitives.d(2504): Attempting to fetch the front of an empty array of TokenStructure!(ubyte, "import dparse.lexer:TokenTriviaFields,TriviaToken; mixin TokenTriviaFields;")
----------------
??:? _d_assert_msg [0x9293bc]
/usr/include/dmd/phobos/std/range/primitives.d:2504 pure nothrow ref @property @nogc @safe inout(std.experimental.lexer.TokenStructure!(ubyte, "import dparse.lexer:TokenTriviaFields,TriviaToken; mixin TokenTriviaFields;").TokenStructure) std.range.primitives.front!(std.experimental.lexer.TokenStructure!(ubyte, "import dparse.lexer:TokenTriviaFields,TriviaToken; mixin TokenTriviaFields;").TokenStructure).front(return scope inout(std.experimental.lexer.TokenStructure!(ubyte, "import dparse.lexer:TokenTriviaFields,TriviaToken; mixin TokenTriviaFields;").TokenStructure)[]) [0x75496b]
/usr/include/dmd/phobos/std/range/package.d:11250 pure nothrow ref @property @nogc @safe const(std.experimental.lexer.TokenStructure!(ubyte, "import dparse.lexer:TokenTriviaFields,TriviaToken; mixin TokenTriviaFields;").TokenStructure) std.range.SortedRange!(const(std.experimental.lexer.TokenStructure!(ubyte, "import dparse.lexer:TokenTriviaFields,TriviaToken; mixin TokenTriviaFields;").TokenStructure)[], "a < b", 0).SortedRange.front() [0x7559aa]
src/dcd/server/autocomplete/util.d:150 dcd.server.autocomplete.util.SymbolStuff dcd.server.autocomplete.util.getSymbolsForCompletion(const(dcd.common.messages.AutocompleteRequest), const(dcd.common.messages.CompletionType), dparse.rollback_allocator.RollbackAllocator*, ref dparse.lexer.StringCache, ref dsymbol.modulecache.ModuleCache) [0x79bea1]
src/dcd/server/autocomplete/doc.d:50 dcd.common.messages.AutocompleteResponse dcd.server.autocomplete.doc.getDoc(const(dcd.common.messages.AutocompleteRequest), ref dsymbol.modulecache.ModuleCache) [0x79a0b2]
src/dcd/server/main.d:342 pure @nogc @safe dcd.common.messages.AutocompleteResponse dcd.server.main.runServer(immutable(char)[][]).__dgliteral69() [0x7d2ad5]
src/dcd/server/main.d:367 void dcd.server.main.trySendResponse(std.socket.Socket, lazy dcd.common.messages.AutocompleteResponse, lazy immutable(char)[]) [0x7d2d86]
src/dcd/server/main.d:342 int dcd.server.main.runServer(immutable(char)[][]) [0x7d2214]
src/dcd/server/main.d:63 _Dmain [0x7d141f]
```