### PR TITLE
tests/extra/tc_ufcs_all_kinds: support gdc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ stdout.txt
 # script-generated expected with absolute file paths
 tests/tc_locate_ufcs_function/expected.txt
 tests/tc_recursive_public_import/expected.txt
+# other script-generated files
+tests/extra/tc_ufcs_all_kinds/generate_tests
 
 # Dub files
 .dub

--- a/tests/extra/tc_ufcs_all_kinds/run.sh
+++ b/tests/extra/tc_ufcs_all_kinds/run.sh
@@ -4,4 +4,26 @@ if [ -z "${DC:-}" ]; then
 	DC=dmd
 fi
 
-DC="$DC" "$DC" -run generate_tests.d "$1"
+DCBASE=$(basename ${DC})
+
+# Set up ERROR_FLAGS to make all compilers output errors in the same
+# format to make matching easier in generate_tests.d. Also make them
+# output all errors.
+if [[ ${DCBASE} == *gdc* ]]; then
+	outputFlag=-o
+	# Not needed as gdc defaults to printing all errors
+	ERROR_FLAGS=
+elif [[ ${DCBASE} == *gdmd* ]]; then
+	outputFlag=-of
+	ERROR_FLAGS=
+elif [[ ${DCBASE} == *ldc* || ${DCBASE} == *dmd* ]]; then
+	outputFlag=-of
+	ERROR_FLAGS='-verrors=0 -verror-style=gnu -vcolumns'
+else
+	echo "Unknown compiler ${DC}"
+	exit 1
+fi
+
+$DC ${outputFlag}generate_tests generate_tests.d
+export DC ERROR_FLAGS
+./generate_tests "${1}"


### PR DESCRIPTION
Remove the usage of `-run` which isn't supported by gdc and only pass `-verrors=0` to dmd and ldc2 since gdc doesn't support the flag and, by default, all errors are printed.

Change the format in which errors are printed to keep it consistent across all the three major compilers (a style that they all support is the gnu style) and make the matching code in generate_tests.d more readable by using a regex.