### PR TITLE
.github/workflows/ci.yml: add gdc build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
 
       - name: Build DSymbol
         env:
-          DC: ${{matrix.dc}}
           LIBDPARSE_VERSION: ${{ matrix.libdparse-version }}
         run: |
           cd dsymbol
@@ -60,7 +59,6 @@ jobs:
 
       - name: Test DSymbol
         env:
-          DC: ${{matrix.dc}}
           LIBDPARSE_VERSION: ${{ matrix.libdparse-version }}
         run: |
           cd dsymbol
@@ -86,3 +84,64 @@ jobs:
         working-directory: tests
         shell: bash
         continue-on-error: true
+
+  Build-gdc:
+    name: Build with gdc
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, dc: gdc-12, libdparse-version: min, build: debug, arch: x86_64 }
+          - { os: ubuntu-latest, dc: gdc-12, libdparse-version: max, build: debug, arch: x86_64 }
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup D tools
+        # Pull in dmd-latest with dub & tools
+        uses: dlang-community/setup-dlang@v1
+        with:
+          compiler: dmd-latest
+
+      - name: Setup D
+        run: |
+          sudo apt update
+          sudo apt install -y gdc-12
+          gdc-12 --version
+          echo "DC=gdc-12" >> "${GITHUB_ENV}"
+
+      - name: Build
+        run: make gdc GDC=$DC
+
+      - name: Build DSymbol
+        env:
+          LIBDPARSE_VERSION: ${{ matrix.libdparse-version }}
+        run: |
+          cd dsymbol
+          rdmd ../d-test-utils/test_with_package.d $LIBDPARSE_VERSION libdparse -- dub build --build=${{ matrix.build }}
+
+      - name: Test DSymbol
+        env:
+          LIBDPARSE_VERSION: ${{ matrix.libdparse-version }}
+          # Get around linking errors in gdc
+          DFLAGS: '-fall-instantiations'
+        run: |
+          cd dsymbol
+          rdmd ../d-test-utils/test_with_package.d $LIBDPARSE_VERSION libdparse -- dub test
+
+      # test that both lowest supplied and highest available libdparse versions are compatible (for DUB users depending on DCD)
+      - name: Test dependency versions
+        env:
+          LIBDPARSE_VERSION: ${{ matrix.libdparse-version }}
+        run: |
+          rm -rf "${HOME}/.dub/packages/libdparse"
+          rdmd ./d-test-utils/test_with_package.d $LIBDPARSE_VERSION libdparse -- make gdc GDC=$DC DPARSE_DIR=~/.dub/packages/libdparse/*/libdparse
+
+      - name: Linux Tests
+        run: ./run_tests.sh --extra
+        working-directory: tests
+        shell: bash


### PR DESCRIPTION
As requested in https://github.com/dlang-community/DCD/pull/774#issuecomment-2085362766 this PR adds a CI job that builds and tests DCD with gdc.

Implementing this has shown some problems:

1. https://github.com/dlang-community/DCD/blob/27b1042959c4d1a27787cf502da14970ab821149/common/dub.sdl#L3 uses `-run` which is unsupported by gdc. One can solve this by using gdmd though
2. gdmd is terribly packaged in ubuntu. It requires gdc which requires gdc-11, forcing gdmd to use a very old D frontend version. This is somehow fixable by manually creating the symlink `/usr/bin/gdmd-12` to `/usr/bin/gdmd` which will use gdc-12.
3. gdmd doesn't work with dub since it adds `-vcolumns` which gdmd doesn't understand. This has been fixed in https://github.com/D-Programming-GDC/gdmd/commit/0a64b92ec5ad1177988496df4f3ca47c47580501 but it will take some time before it makes its way into downstream packages.

These issues can be sidestepped if the makefile is used to build the package instead of dub. This only complicates things a little in the case of testing multiple libdparse versions which was a requirement of https://github.com/dlang-community/DCD/pull/774#issuecomment-2085426841.

I've chosen to write a separate job instead of adding to the old one as most of the steps are different and adding `if compiler == gdc` and `if compiler != gdc` everywhere didn't seem good. The useless `DC` exports have been removed as `setup-dlang` already sets the environment variable.

