### PR TITLE
Skip forward declaration

### DIFF
--- a/dsymbol/src/dsymbol/conversion/first.d
+++ b/dsymbol/src/dsymbol/conversion/first.d
@@ -874,6 +874,14 @@ private:
 			dec.accept(this);
 			return;
 		}
+		// Skip forward declarations (struct Foo;) only process full definitions
+		// otherwise it'll overwrite the useful one, and dmd -H has the tendency to
+		// generate a lot of them specially with ImportC
+		static if (!is(AggType == const(TemplateDeclaration)))
+		{
+			if (dec.structBody is null)
+				return;
+		}
 		pushSymbol(dec.name.text, kind, symbolFile, dec.name.index);
 		scope(exit) popSymbol();
 

--- a/dsymbol/src/dsymbol/conversion/first.d
+++ b/dsymbol/src/dsymbol/conversion/first.d
@@ -879,7 +879,7 @@ private:
 		// generate a lot of them specially with ImportC
 		static if (!is(AggType == const(TemplateDeclaration)))
 		{
-			if (dec.structBody is null)
+			if (dec.structBody is null && (kind == CompletionKind.structName || kind == CompletionKind.unionName))
 				return;
 		}
 		pushSymbol(dec.name.text, kind, symbolFile, dec.name.index);


### PR DESCRIPTION
Skip forward declarations (struct Foo;) only process full definitions otherwise it'll overwrite the useful one, and dmd -H has the tendency to generate a lot of them specially with ImportC