### PR TITLE
Create proper call tip for struct/union

### DIFF
--- a/dsymbol/src/dsymbol/conversion/first.d
+++ b/dsymbol/src/dsymbol/conversion/first.d
@@ -276,14 +276,6 @@ final class FirstPass : ASTVisitor
 				symbol.acSymbol.doc = makeDocumentation(dec.comment);
 				currentSymbol.addChild(symbol, true);
 				currentScope.addSymbol(symbol.acSymbol, false);
-
-				if (currentSymbol.acSymbol.kind == CompletionKind.structName
-					|| currentSymbol.acSymbol.kind == CompletionKind.unionName)
-				{
-					structFieldNames.insert(symbol.acSymbol.name);
-					// TODO: remove this cast. See the note on structFieldTypes
-					structFieldTypes.insert(null);
-				}
 			}
 		}
 	}
@@ -457,6 +449,8 @@ final class FirstPass : ASTVisitor
 				|| currentSymbol.acSymbol.kind == CompletionKind.unionName)
 				&& currentSymbol.acSymbol.getFirstPartNamed(CONSTRUCTOR_SYMBOL_NAME) is null)
 			createConstructor();
+
+		createCallTip();
 	}
 
 	override void visit(const ImportDeclaration importDeclaration)
@@ -811,6 +805,39 @@ private:
 			CompletionKind.functionName, symbolFile, currentSymbol.acSymbol.location);
 		symbol.acSymbol.callTip = istring(app.data);
 		currentSymbol.addChild(symbol, true);
+	}
+
+	void createCallTip()
+	{
+		import std.range : zip;
+
+		auto app = appender!string();
+
+		switch (currentSymbol.acSymbol.kind)
+		{
+			case CompletionKind.structName: app.put("struct "); break;
+			case CompletionKind.unionName: app.put("union "); break;
+
+			default: app.put("auto ");
+		}
+
+		app.put(currentSymbol.acSymbol.name.data);
+		app.put(" {\n");
+		foreach (field; zip(structFieldTypes[], structFieldNames[]))
+		{
+			if (field[0] is null)
+				app.put("    auto ");
+			else
+			{
+				app.put("    ");
+				app.formatNode(field[0]);
+				app.put(" ");
+			}
+			app.put(field[1].data);
+			app.put(";\n");
+		}
+		app.put("}");
+		currentSymbol.acSymbol.callTip = istring(app.data);
 	}
 
 	void pushScope(size_t startLocation, size_t endLocation)

--- a/dsymbol/src/dsymbol/conversion/first.d
+++ b/dsymbol/src/dsymbol/conversion/first.d
@@ -853,24 +853,26 @@ private:
 			app.put(";\n");
 		}
 
-		if (structFieldStatic.length > 0)
+		bool first = false;
+		foreach (field; zip(structFieldTypes[], structFieldNames[], structFieldStatic[]))
 		{
-			app.put("    // static fields\n");
-			foreach (field; zip(structFieldTypes[], structFieldNames[], structFieldStatic[]))
+			if (field[2] == false) continue;
+			if (!first)
 			{
-				if (field[2] == false) continue;
-
-				if (field[0] is null)
-					app.put("    auto ");
-				else
-				{
-					app.put("    ");
-					app.formatNode(field[0]);
-					app.put(" ");
-				}
-				app.put(field[1].data);
-				app.put(";\n");
+				app.put("    // static fields\n");
+				first = true;
 			}
+
+			if (field[0] is null)
+				app.put("    auto ");
+			else
+			{
+				app.put("    ");
+				app.formatNode(field[0]);
+				app.put(" ");
+			}
+			app.put(field[1].data);
+			app.put(";\n");
 		}
 
 		app.put("}");

--- a/dsymbol/src/dsymbol/conversion/first.d
+++ b/dsymbol/src/dsymbol/conversion/first.d
@@ -450,7 +450,9 @@ final class FirstPass : ASTVisitor
 				&& currentSymbol.acSymbol.getFirstPartNamed(CONSTRUCTOR_SYMBOL_NAME) is null)
 			createConstructor();
 
-		createCallTip();
+		if (currentSymbol.acSymbol.kind == CompletionKind.structName
+				|| currentSymbol.acSymbol.kind == CompletionKind.unionName)
+			createCallTip();
 	}
 
 	override void visit(const ImportDeclaration importDeclaration)

--- a/dsymbol/src/dsymbol/conversion/first.d
+++ b/dsymbol/src/dsymbol/conversion/first.d
@@ -1297,6 +1297,9 @@ private:
 	/// Field names for struct constructor generation
 	UnrolledList!(istring) structFieldNames;
 
+	/// Wether they are static or not
+	UnrolledList!(bool) structFieldStatic;
+
 	/// Last comment for ditto-ing
 	istring lastComment;
 

--- a/dsymbol/src/dsymbol/conversion/first.d
+++ b/dsymbol/src/dsymbol/conversion/first.d
@@ -261,6 +261,7 @@ final class FirstPass : ASTVisitor
 				structFieldNames.insert(symbol.acSymbol.name);
 				// TODO: remove this cast. See the note on structFieldTypes
 				structFieldTypes.insert(cast() dec.type);
+				structFieldStatic.insert(false);
 			}
 		}
 		if (dec.autoDeclaration !is null)
@@ -276,6 +277,15 @@ final class FirstPass : ASTVisitor
 				symbol.acSymbol.doc = makeDocumentation(dec.comment);
 				currentSymbol.addChild(symbol, true);
 				currentScope.addSymbol(symbol.acSymbol, false);
+
+				if (currentSymbol.acSymbol.kind == CompletionKind.structName
+					|| currentSymbol.acSymbol.kind == CompletionKind.unionName)
+				{
+					structFieldNames.insert(symbol.acSymbol.name);
+					// TODO: remove this cast. See the note on structFieldTypes
+					structFieldTypes.insert(null);
+					structFieldStatic.insert(true);
+				}
 			}
 		}
 	}
@@ -430,8 +440,10 @@ final class FirstPass : ASTVisitor
 
 		auto savedStructFieldNames = move(structFieldNames);
 		auto savedStructFieldTypes = move(structFieldTypes);
+		auto savedStructFieldStatic = move(structFieldStatic);
 		scope(exit) structFieldNames = move(savedStructFieldNames);
 		scope(exit) structFieldTypes = move(savedStructFieldTypes);
+		scope(exit) structFieldStatic = move(savedStructFieldStatic);
 
 		DSymbol* thisSymbol = GCAllocator.instance.make!DSymbol(THIS_SYMBOL_NAME,
 			CompletionKind.variableName, currentSymbol.acSymbol);
@@ -825,8 +837,10 @@ private:
 
 		app.put(currentSymbol.acSymbol.name.data);
 		app.put(" {\n");
-		foreach (field; zip(structFieldTypes[], structFieldNames[]))
+		foreach (field; zip(structFieldTypes[], structFieldNames[], structFieldStatic[]))
 		{
+			if (field[2] == true) continue;
+
 			if (field[0] is null)
 				app.put("    auto ");
 			else
@@ -838,6 +852,27 @@ private:
 			app.put(field[1].data);
 			app.put(";\n");
 		}
+
+		if (structFieldStatic.length > 0)
+		{
+			app.put("    // static fields\n");
+			foreach (field; zip(structFieldTypes[], structFieldNames[], structFieldStatic[]))
+			{
+				if (field[2] == false) continue;
+
+				if (field[0] is null)
+					app.put("    auto ");
+				else
+				{
+					app.put("    ");
+					app.formatNode(field[0]);
+					app.put(" ");
+				}
+				app.put(field[1].data);
+				app.put(";\n");
+			}
+		}
+
 		app.put("}");
 		currentSymbol.acSymbol.callTip = istring(app.data);
 	}


### PR DESCRIPTION
- struct fields for ctor should not contain any static fields (__gshared/enum/static)
- callTip for struct/union now properly built

<img width="365" height="539" alt="image" src="https://github.com/user-attachments/assets/79c5128d-8536-4fed-9a09-44af95e97311" />


<img width="747" height="157" alt="image" src="https://github.com/user-attachments/assets/6cb2d6d5-8d25-4218-982c-54827565137b" />
